### PR TITLE
Add web status route

### DIFF
--- a/src/ahriman/application/ahriman.py
+++ b/src/ahriman/application/ahriman.py
@@ -22,9 +22,8 @@ import sys
 
 from pathlib import Path
 
-import ahriman.application.handlers as handlers
-import ahriman.version as version
-
+from ahriman import version
+from ahriman.application import handlers
 from ahriman.models.build_status import BuildStatusEnum
 from ahriman.models.sign_settings import SignSettings
 

--- a/src/ahriman/core/status/client.py
+++ b/src/ahriman/core/status/client.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Tuple, Type
 
 from ahriman.core.configuration import Configuration
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
+from ahriman.models.internal_status import InternalStatus
 from ahriman.models.package import Package
 
 
@@ -61,6 +62,14 @@ class Client:
         """
         del base
         return []
+
+    # pylint: disable=no-self-use
+    def get_internal(self) -> InternalStatus:
+        """
+        get internal service status
+        :return: current internal (web) service status
+        """
+        return InternalStatus()
 
     # pylint: disable=no-self-use
     def get_self(self) -> BuildStatus:

--- a/src/ahriman/models/counters.py
+++ b/src/ahriman/models/counters.py
@@ -1,0 +1,71 @@
+#
+# Copyright (c) 2021 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List, Tuple, Type
+
+from ahriman.models.build_status import BuildStatus
+from ahriman.models.package import Package
+
+
+@dataclass
+class Counters:
+    """
+    package counters
+    :ivar total: total packages count
+    :ivar unknown: packages in unknown status count
+    :ivar pending: packages in pending status count
+    :ivar building: packages in building status count
+    :ivar failed: packages in failed status count
+    :ivar success: packages in success status count
+    """
+    total: int
+    unknown: int = 0
+    pending: int = 0
+    building: int = 0
+    failed: int = 0
+    success: int = 0
+
+    @classmethod
+    def from_json(cls: Type[Counters], dump: Dict[str, Any]) -> Counters:
+        """
+        construct counters from json dump
+        :param dump: json dump body
+        :return: status counters
+        """
+        # filter to only known fields
+        known_fields = [pair.name for pair in fields(cls)]
+        dump = {key: value for key, value in dump.items() if key in known_fields}
+        return cls(**dump)
+
+    @classmethod
+    def from_packages(cls: Type[Counters], packages: List[Tuple[Package, BuildStatus]]) -> Counters:
+        """
+        construct counters from packages statuses
+        :param packages: list of package and their status as per watcher property
+        :return: status counters
+        """
+        per_status = {"total": len(packages)}
+        for _, status in packages:
+            key = status.status.name.lower()
+            per_status.setdefault(key, 0)
+            per_status[key] += 1
+        return cls(**per_status)

--- a/src/ahriman/models/internal_status.py
+++ b/src/ahriman/models/internal_status.py
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2021 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional, Type
+
+from ahriman.models.counters import Counters
+
+
+@dataclass
+class InternalStatus:
+    """
+    internal server status
+    :ivar architecture: repository architecture
+    :ivar packages: packages statuses counter object
+    :ivar repository: repository name
+    :ivar version: service version
+    """
+    architecture: Optional[str] = None
+    packages: Counters = field(default=Counters(total=0))
+    repository: Optional[str] = None
+    version: Optional[str] = None
+
+    @classmethod
+    def from_json(cls: Type[InternalStatus], dump: Dict[str, Any]) -> InternalStatus:
+        """
+        construct internal status from json dump
+        :param dump: json dump body
+        :return: internal status
+        """
+        counters = Counters.from_json(dump["packages"]) if "packages" in dump else Counters(total=0)
+        return cls(architecture=dump.get("architecture"),
+                   packages=counters,
+                   repository=dump.get("repository"),
+                   version=dump.get("version"))
+
+    def view(self) -> Dict[str, Any]:
+        """
+        generate json status view
+        :return: json-friendly dictionary
+        """
+        return asdict(self)

--- a/src/ahriman/web/routes.py
+++ b/src/ahriman/web/routes.py
@@ -23,6 +23,7 @@ from ahriman.web.views.ahriman import AhrimanView
 from ahriman.web.views.index import IndexView
 from ahriman.web.views.package import PackageView
 from ahriman.web.views.packages import PackagesView
+from ahriman.web.views.status import StatusView
 
 
 def setup_routes(application: Application) -> None:
@@ -44,6 +45,8 @@ def setup_routes(application: Application) -> None:
         GET /api/v1/package/:base       get package base status
         POST /api/v1/package/:base      update package base status
 
+        GET /api/v1/status              get web service status itself
+
     :param application: web application instance
     """
     application.router.add_get("/", IndexView)
@@ -58,3 +61,5 @@ def setup_routes(application: Application) -> None:
     application.router.add_delete("/api/v1/packages/{package}", PackageView)
     application.router.add_get("/api/v1/packages/{package}", PackageView)
     application.router.add_post("/api/v1/packages/{package}", PackageView)
+
+    application.router.add_get("/api/v1/status", StatusView)

--- a/src/ahriman/web/views/index.py
+++ b/src/ahriman/web/views/index.py
@@ -21,8 +21,7 @@ import aiohttp_jinja2
 
 from typing import Any, Dict
 
-import ahriman.version as version
-
+from ahriman import version
 from ahriman.core.util import pretty_datetime
 from ahriman.web.views.base import BaseView
 

--- a/src/ahriman/web/views/status.py
+++ b/src/ahriman/web/views/status.py
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2021 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from aiohttp.web import Response, json_response
+
+import ahriman.version as version
+
+from ahriman.web.views.base import BaseView
+
+
+class StatusView(BaseView):
+    """
+    web service status web view
+    """
+
+    async def get(self) -> Response:
+        """
+        get current service status
+        :return: 200 with service status object
+        """
+        packages = self.service.packages
+        per_status = {"total": len(packages)}
+        for _, status in packages:
+            per_status.setdefault(status.status.name, 0)
+            per_status[status.status.name] += 1
+
+        data = {
+            "architecture": self.service.architecture,
+            "packages": per_status,
+            "repository": self.service.repository.name,
+            "version": version.__version__,
+        }
+        return json_response(data)

--- a/tests/ahriman/core/status/test_client.py
+++ b/tests/ahriman/core/status/test_client.py
@@ -4,6 +4,7 @@ from ahriman.core.configuration import Configuration
 from ahriman.core.status.client import Client
 from ahriman.core.status.web_client import WebClient
 from ahriman.models.build_status import BuildStatusEnum
+from ahriman.models.internal_status import InternalStatus
 from ahriman.models.package import Package
 
 
@@ -36,6 +37,13 @@ def test_get(client: Client, package_ahriman: Package) -> None:
     """
     assert client.get(package_ahriman.base) == []
     assert client.get(None) == []
+
+
+def test_get_internal(client: Client) -> None:
+    """
+    must return dummy status for web service
+    """
+    assert client.get_internal() == InternalStatus()
 
 
 def test_get_self(client: Client) -> None:

--- a/tests/ahriman/models/conftest.py
+++ b/tests/ahriman/models/conftest.py
@@ -2,7 +2,10 @@ import pytest
 
 from unittest.mock import MagicMock, PropertyMock
 
+from ahriman import version
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
+from ahriman.models.counters import Counters
+from ahriman.models.internal_status import InternalStatus
 from ahriman.models.package import Package
 from ahriman.models.package_description import PackageDescription
 
@@ -10,6 +13,24 @@ from ahriman.models.package_description import PackageDescription
 @pytest.fixture
 def build_status_failed() -> BuildStatus:
     return BuildStatus(BuildStatusEnum.Failed, 42)
+
+
+@pytest.fixture
+def counters() -> Counters:
+    return Counters(total=10,
+                    unknown=1,
+                    pending=2,
+                    building=3,
+                    failed=4,
+                    success=0)
+
+
+@pytest.fixture
+def internal_status(counters: Counters) -> InternalStatus:
+    return InternalStatus(architecture="x86_64",
+                          packages=counters,
+                          version=version.__version__,
+                          repository="aur-clone")
 
 
 @pytest.fixture

--- a/tests/ahriman/models/test_counters.py
+++ b/tests/ahriman/models/test_counters.py
@@ -1,0 +1,31 @@
+from dataclasses import asdict
+
+from ahriman.models.build_status import BuildStatus, BuildStatusEnum
+from ahriman.models.counters import Counters
+from ahriman.models.package import Package
+
+
+def test_counters_from_json_view(counters: Counters) -> None:
+    """
+    must construct same object from json
+    """
+    assert Counters.from_json(asdict(counters)) == counters
+
+
+def test_counters_from_packages(package_ahriman: Package, package_python_schedule: Package) -> None:
+    """
+    must construct object from list of packages with their statuses
+    """
+    payload = [
+        (package_ahriman, BuildStatus(status=BuildStatusEnum.Success)),
+        (package_python_schedule, BuildStatus(status=BuildStatusEnum.Failed)),
+    ]
+
+    counters = Counters.from_packages(payload)
+    assert counters.total == 2
+    assert counters.success == 1
+    assert counters.failed == 1
+
+    json = asdict(counters)
+    total = json.pop("total")
+    assert total == sum(i for i in json.values())

--- a/tests/ahriman/models/test_internal_status.py
+++ b/tests/ahriman/models/test_internal_status.py
@@ -1,0 +1,8 @@
+from ahriman.models.internal_status import InternalStatus
+
+
+def test_internal_status_from_json_view(internal_status: InternalStatus) -> None:
+    """
+    must construct same object from json
+    """
+    assert InternalStatus.from_json(internal_status.view()) == internal_status

--- a/tests/ahriman/web/views/test_view_status.py
+++ b/tests/ahriman/web/views/test_view_status.py
@@ -1,0 +1,22 @@
+from pytest_aiohttp import TestClient
+
+import ahriman.version as version
+
+from ahriman.models.build_status import BuildStatusEnum
+from ahriman.models.package import Package
+
+
+async def test_get(client: TestClient, package_ahriman: Package) -> None:
+    """
+    must generate web service status correctly)
+    """
+    await client.post(f"/api/v1/packages/{package_ahriman.base}",
+                      json={"status": BuildStatusEnum.Success.value, "package": package_ahriman.view()})
+
+    response = await client.get("/api/v1/status")
+    assert response.status == 200
+
+    json = await response.json()
+    assert json["version"] == version.__version__
+    assert json["packages"]
+    assert json["packages"]["total"] == 1


### PR DESCRIPTION
## Summary

Simple web status json view at `/api/v1/status`, closes #12 

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
