### PR TITLE
imply no-log for every unsafe parser

### DIFF
--- a/src/ahriman/application/ahriman.py
+++ b/src/ahriman/application/ahriman.py
@@ -115,7 +115,7 @@ def _set_clean_parser(root: SubParserAction) -> argparse.ArgumentParser:
     parser.add_argument("--no-chroot", help="do not clear build chroot", action="store_true")
     parser.add_argument("--no-manual", help="do not clear directory with manually added packages", action="store_true")
     parser.add_argument("--no-packages", help="do not clear directory with built packages", action="store_true")
-    parser.set_defaults(handler=handlers.Clean, unsafe=True)
+    parser.set_defaults(handler=handlers.Clean, no_log=True, unsafe=True)
     return parser
 
 
@@ -128,7 +128,7 @@ def _set_config_parser(root: SubParserAction) -> argparse.ArgumentParser:
     parser = root.add_parser("config", help="dump configuration",
                              description="dump configuration for specified architecture",
                              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.set_defaults(handler=handlers.Dump, lock=None, no_report=True, unsafe=True)
+    parser.set_defaults(handler=handlers.Dump, lock=None, no_log=True, no_report=True, unsafe=True)
     return parser
 
 
@@ -194,7 +194,7 @@ def _set_search_parser(root: SubParserAction) -> argparse.ArgumentParser:
     """
     parser = root.add_parser("search", help="search for package", description="search for package in AUR using API")
     parser.add_argument("search", help="search terms, can be specified multiple times", nargs="+")
-    parser.set_defaults(handler=handlers.Search, lock=None, no_report=True, unsafe=True)
+    parser.set_defaults(handler=handlers.Search, lock=None, no_log=True, no_report=True, unsafe=True)
     return parser
 
 
@@ -217,7 +217,7 @@ def _set_setup_parser(root: SubParserAction) -> argparse.ArgumentParser:
     parser.add_argument("--sign-target", help="sign options", type=SignSettings.from_option,
                         choices=SignSettings, action="append")
     parser.add_argument("--web-port", help="port of the web service", type=int)
-    parser.set_defaults(handler=handlers.Setup, lock=None, no_report=True, unsafe=True)
+    parser.set_defaults(handler=handlers.Setup, lock=None, no_log=True, no_report=True, unsafe=True)
     return parser
 
 
@@ -244,7 +244,7 @@ def _set_status_parser(root: SubParserAction) -> argparse.ArgumentParser:
                              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--ahriman", help="get service status itself", action="store_true")
     parser.add_argument("package", help="filter status by package base", nargs="*")
-    parser.set_defaults(handler=handlers.Status, lock=None, no_report=True, unsafe=True)
+    parser.set_defaults(handler=handlers.Status, lock=None, no_log=True, no_report=True, unsafe=True)
     return parser
 
 
@@ -263,7 +263,7 @@ def _set_status_update_parser(root: SubParserAction) -> argparse.ArgumentParser:
     parser.add_argument("--status", help="new status", choices=BuildStatusEnum,
                         type=BuildStatusEnum, default=BuildStatusEnum.Success)
     parser.add_argument("--remove", help="remove package status page", action="store_true")
-    parser.set_defaults(handler=handlers.StatusUpdate, lock=None, no_report=True, unsafe=True)
+    parser.set_defaults(handler=handlers.StatusUpdate, lock=None, no_log=True, no_report=True, unsafe=True)
     return parser
 
 

--- a/tests/ahriman/application/test_ahriman.py
+++ b/tests/ahriman/application/test_ahriman.py
@@ -55,18 +55,20 @@ def test_subparsers_check(parser: argparse.ArgumentParser) -> None:
 
 def test_subparsers_clean(parser: argparse.ArgumentParser) -> None:
     """
-    clean command must imply unsafe
+    clean command must imply unsafe and no-log
     """
     args = parser.parse_args(["-a", "x86_64", "clean"])
+    assert args.no_log
     assert args.unsafe
 
 
 def test_subparsers_config(parser: argparse.ArgumentParser) -> None:
     """
-    config command must imply lock, no_report and unsafe
+    config command must imply lock, no_log, no_report and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "config"])
     assert args.lock is None
+    assert args.no_log
     assert args.no_report
     assert args.unsafe
 
@@ -82,21 +84,23 @@ def test_subparsers_key_import(parser: argparse.ArgumentParser) -> None:
 
 def test_subparsers_search(parser: argparse.ArgumentParser) -> None:
     """
-    search command must imply lock, no_report and unsafe
+    search command must imply lock, no_log, no_report and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "search", "ahriman"])
     assert args.lock is None
+    assert args.no_log
     assert args.no_report
     assert args.unsafe
 
 
 def test_subparsers_setup(parser: argparse.ArgumentParser) -> None:
     """
-    setup command must imply lock, no_report and unsafe
+    setup command must imply lock, no_log, no_report and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "setup", "--packager", "John Doe <john@doe.com>",
                               "--repository", "aur-clone"])
     assert args.lock is None
+    assert args.no_log
     assert args.no_report
     assert args.unsafe
 
@@ -125,20 +129,22 @@ def test_subparsers_setup_option_sign_target(parser: argparse.ArgumentParser) ->
 
 def test_subparsers_status(parser: argparse.ArgumentParser) -> None:
     """
-    status command must imply lock, no_report and unsafe
+    status command must imply lock, no_log, no_report and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "status"])
     assert args.lock is None
+    assert args.no_log
     assert args.no_report
     assert args.unsafe
 
 
 def test_subparsers_status_update(parser: argparse.ArgumentParser) -> None:
     """
-    status-update command must imply lock, no_report and unsafe
+    status-update command must imply lock, no_log, no_report and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "status-update"])
     assert args.lock is None
+    assert args.no_log
     assert args.no_report
     assert args.unsafe
 


### PR DESCRIPTION
## Summary

Just add no-log defaults for every unsafe run. Closes #19 

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
