### PR TITLE
Expiration on server side support

### DIFF
--- a/src/ahriman/models/user_identity.py
+++ b/src/ahriman/models/user_identity.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2021 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+import time
+
+from dataclasses import dataclass
+from typing import Optional, Type
+
+
+@dataclass
+class UserIdentity:
+    """
+    user identity used inside web service
+    :ivar username: username
+    :ivar expire_at: identity expiration timestamp
+    """
+
+    username: str
+    expire_at: int
+
+    @classmethod
+    def from_identity(cls: Type[UserIdentity], identity: str) -> Optional[UserIdentity]:
+        """
+        parse identity into object
+        :param identity: identity from session data
+        :return: user identity object if it can be parsed and not expired and None otherwise
+        """
+        try:
+            username, expire_at = identity.split()
+            user = cls(username, int(expire_at))
+            return None if user.is_expired() else user
+        except ValueError:
+            return None
+
+    @classmethod
+    def from_username(cls: Type[UserIdentity], username: Optional[str], max_age: int) -> Optional[UserIdentity]:
+        """
+        generate identity from username
+        :param username: username
+        :param max_age: time to expire, seconds
+        :return: constructed identity object
+        """
+        return cls(username, cls.expire_when(max_age)) if username is not None else None
+
+    @staticmethod
+    def expire_when(max_age: int) -> int:
+        """
+        generate expiration time using delta
+        :param max_age: time delta to generate. Must be usually TTE
+        :return: expiration timestamp
+        """
+        return int(time.time()) + max_age
+
+    def is_expired(self) -> bool:
+        """
+        compare timestamp with current timestamp and return True in case if identity is expired
+        :return: True in case if identity is expired and False otherwise
+        """
+        return self.expire_when(0) > self.expire_at
+
+    def to_identity(self) -> str:
+        """
+        convert object to identity representation
+        :return: web service identity
+        """
+        return f"{self.username} {self.expire_at}"

--- a/tests/ahriman/models/conftest.py
+++ b/tests/ahriman/models/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 
 from unittest.mock import MagicMock, PropertyMock
 
@@ -8,6 +9,7 @@ from ahriman.models.counters import Counters
 from ahriman.models.internal_status import InternalStatus
 from ahriman.models.package import Package
 from ahriman.models.package_description import PackageDescription
+from ahriman.models.user_identity import UserIdentity
 
 
 @pytest.fixture
@@ -104,3 +106,12 @@ def pyalpm_package_description_ahriman(package_description_ahriman: PackageDescr
     type(mock).provides = PropertyMock(return_value=package_description_ahriman.provides)
     type(mock).url = PropertyMock(return_value=package_description_ahriman.url)
     return mock
+
+
+@pytest.fixture
+def user_identity() -> UserIdentity:
+    """
+    identity fixture
+    :return: user identity test instance
+    """
+    return UserIdentity("username", int(time.time()) + 30)

--- a/tests/ahriman/models/test_user_identity.py
+++ b/tests/ahriman/models/test_user_identity.py
@@ -1,0 +1,64 @@
+from ahriman.models.user_identity import UserIdentity
+
+
+def test_from_identity(user_identity: UserIdentity) -> None:
+    """
+    must construct identity object from string
+    """
+    identity = UserIdentity.from_identity(f"{user_identity.username} {user_identity.expire_at}")
+    assert identity == user_identity
+
+
+def test_from_identity_expired(user_identity: UserIdentity) -> None:
+    """
+    must construct None from expired identity
+    """
+    user_identity.expire_at -= 60
+    assert UserIdentity.from_identity(f"{user_identity.username} {user_identity.expire_at}") is None
+
+
+def test_from_identity_no_split() -> None:
+    """
+    must construct None from invalid string
+    """
+    assert UserIdentity.from_identity("username") is None
+
+
+def test_from_identity_not_int() -> None:
+    """
+    must construct None from invalid timestamp
+    """
+    assert UserIdentity.from_identity("username timestamp") is None
+
+
+def test_from_username() -> None:
+    """
+    must construct identity from username
+    """
+    identity = UserIdentity.from_username("username", 0)
+    assert identity.username == "username"
+    # we want to check timestamp too, but later
+
+
+def test_expire_when() -> None:
+    """
+    must return correct expiration time
+    """
+    assert UserIdentity.expire_when(-1) < UserIdentity.expire_when(0) < UserIdentity.expire_when(1)
+
+
+def test_is_expired(user_identity: UserIdentity) -> None:
+    """
+    must return expired flag for expired identities
+    """
+    assert not user_identity.is_expired()
+
+    user_identity.expire_at -= 60
+    assert user_identity.is_expired()
+
+
+def test_to_identity(user_identity: UserIdentity) -> None:
+    """
+    must return correct identity string
+    """
+    assert user_identity == UserIdentity.from_identity(user_identity.to_identity())

--- a/tests/ahriman/web/views/user/test_views_user_login.py
+++ b/tests/ahriman/web/views/user/test_views_user_login.py
@@ -45,7 +45,8 @@ async def test_get(client_with_auth: TestClient, mocker: MockerFixture) -> None:
     oauth = client_with_auth.app["validator"] = MagicMock(spec=OAuth)
     oauth.get_oauth_username.return_value = "user"
     oauth.known_username.return_value = True
-    oauth.enabled = False  # lol
+    oauth.enabled = False  # lol\
+    oauth.max_age = 60
     remember_mock = mocker.patch("aiohttp_security.remember")
 
     get_response = await client_with_auth.get("/user-api/v1/login", params={"code": "code"})
@@ -62,6 +63,7 @@ async def test_get_unauthorized(client_with_auth: TestClient, mocker: MockerFixt
     """
     oauth = client_with_auth.app["validator"] = MagicMock(spec=OAuth)
     oauth.known_username.return_value = False
+    oauth.max_age = 60
     remember_mock = mocker.patch("aiohttp_security.remember")
 
     get_response = await client_with_auth.get("/user-api/v1/login", params={"code": "code"})


### PR DESCRIPTION
## Summary

Support of identity expiration via extending identity to timestamp.

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
