### PR TITLE
handle packages which have been removed from the repository

### DIFF
--- a/src/ahriman/application/formatters/string_printer.py
+++ b/src/ahriman/application/formatters/string_printer.py
@@ -20,24 +20,23 @@
 from typing import Optional
 
 from ahriman.application.formatters.printer import Printer
-from ahriman.models.build_status import BuildStatus
 
 
-class StatusPrinter(Printer):
+class StringPrinter(Printer):
     """
-    print content of the status object
+    print content of the random string
     """
 
-    def __init__(self, status: BuildStatus) -> None:
+    def __init__(self, content: str) -> None:
         """
         default constructor
-        :param status: build status
+        :param content: any content string
         """
-        self.content = status
+        self.content = content
 
     def title(self) -> Optional[str]:
         """
         generate entry title from content
         :return: content title if it can be generated and None otherwise
         """
-        return self.content.pretty_print()
+        return self.content

--- a/src/ahriman/application/handlers/remove_unknown.py
+++ b/src/ahriman/application/handlers/remove_unknown.py
@@ -22,10 +22,9 @@ import argparse
 from typing import Type
 
 from ahriman.application.application import Application
-from ahriman.application.formatters.package_printer import PackagePrinter
+from ahriman.application.formatters.string_printer import StringPrinter
 from ahriman.application.handlers.handler import Handler
 from ahriman.core.configuration import Configuration
-from ahriman.models.build_status import BuildStatus
 
 
 class RemoveUnknown(Handler):
@@ -46,8 +45,8 @@ class RemoveUnknown(Handler):
         application = Application(architecture, configuration, no_report)
         unknown_packages = application.unknown()
         if args.dry_run:
-            for package in unknown_packages:
-                PackagePrinter(package, BuildStatus()).print(args.info)
+            for package in sorted(unknown_packages):
+                StringPrinter(package).print(args.info)
             return
 
-        application.remove(package.base for package in unknown_packages)
+        application.remove(unknown_packages)

--- a/src/ahriman/core/exceptions.py
+++ b/src/ahriman/core/exceptions.py
@@ -153,8 +153,12 @@ class UnknownPackage(ValueError):
     exception for status watcher which will be thrown on unknown package
     """
 
-    def __init__(self, base: str) -> None:
-        ValueError.__init__(self, f"Package base {base} is unknown")
+    def __init__(self, package_base: str) -> None:
+        """
+        default constructor
+        :param package_base: package base name
+        """
+        ValueError.__init__(self, f"Package base {package_base} is unknown")
 
 
 class UnsafeRun(RuntimeError):
@@ -165,9 +169,9 @@ class UnsafeRun(RuntimeError):
     def __init__(self, current_uid: int, root_uid: int) -> None:
         """
         default constructor
+        :param current_uid: current user ID
+        :param root_uid: ID of the owner of root directory
         """
-        RuntimeError.__init__(
-            self,
-            f"""Current UID {current_uid} differs from root owner {root_uid}.
-Note that for the most actions it is unsafe to run application as different user.
-If you are 100% sure that it must be there try --unsafe option""")
+        RuntimeError.__init__(self, f"Current UID {current_uid} differs from root owner {root_uid}. "
+                                    f"Note that for the most actions it is unsafe to run application as different user."
+                                    f" If you are 100% sure that it must be there try --unsafe option")

--- a/src/ahriman/core/repository/executor.py
+++ b/src/ahriman/core/repository/executor.py
@@ -20,7 +20,7 @@
 import shutil
 
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Set
 
 from ahriman.core.build_tools.task import Task
 from ahriman.core.report.report import Report
@@ -159,15 +159,24 @@ class Executor(Cleaner):
             package_path = self.paths.repository / name
             self.repo.add(package_path)
 
+        current_packages = self.packages()
+        removed_packages: List[str] = []  # list of packages which have been removed from the base
         updates = self.load_archives(packages)
+
         for local in updates:
             try:
                 for description in local.packages.values():
                     update_single(description.filename, local.base)
                 self.reporter.set_success(local)
+
+                current_package_archives: Set[str] = next(
+                    (set(current.packages) for current in current_packages if current.base == local.base), set())
+                removed_packages.extend(current_package_archives.difference(local.packages))
             except Exception:
                 self.reporter.set_failed(local.base)
                 self.logger.exception("could not process %s", local.base)
         self.clear_packages()
+
+        self.process_remove(removed_packages)
 
         return self.repo.repo_path

--- a/src/ahriman/models/package.py
+++ b/src/ahriman/models/package.py
@@ -257,14 +257,15 @@ class Package:
 
         return self.version
 
-    def is_outdated(self, remote: Package, paths: RepositoryPaths) -> bool:
+    def is_outdated(self, remote: Package, paths: RepositoryPaths, calculate_version: bool = True) -> bool:
         """
         check if package is out-of-dated
         :param remote: package properties from remote source
         :param paths: repository paths instance. Required for VCS packages cache
+        :param calculate_version: expand version to actual value (by calculating git versions)
         :return: True if the package is out-of-dated and False otherwise
         """
-        remote_version = remote.actual_version(paths)  # either normal version or updated VCS
+        remote_version = remote.actual_version(paths) if calculate_version else remote.version
         result: int = vercmp(self.version, remote_version)
         return result < 0
 

--- a/tests/ahriman/application/application/test_application_repository.py
+++ b/tests/ahriman/application/application/test_application_repository.py
@@ -147,6 +147,7 @@ def test_unknown_no_aur(application_repository: Repository, package_ahriman: Pac
     """
     mocker.patch("ahriman.core.repository.repository.Repository.packages", return_value=[package_ahriman])
     mocker.patch("ahriman.models.package.Package.from_aur", side_effect=Exception())
+    mocker.patch("ahriman.models.package.Package.from_build", return_value=package_ahriman)
     mocker.patch("pathlib.Path.is_dir", return_value=True)
     mocker.patch("ahriman.core.build_tools.sources.Sources.has_remotes", return_value=False)
 
@@ -163,7 +164,7 @@ def test_unknown_no_aur_no_local(application_repository: Repository, package_ahr
     mocker.patch("pathlib.Path.is_dir", return_value=False)
 
     packages = application_repository.unknown()
-    assert packages == [package_ahriman]
+    assert packages == list(package_ahriman.packages.keys())
 
 
 def test_unknown_no_local(application_repository: Repository, package_ahriman: Package, mocker: MockerFixture) -> None:

--- a/tests/ahriman/application/formatters/conftest.py
+++ b/tests/ahriman/application/formatters/conftest.py
@@ -5,6 +5,7 @@ from ahriman.application.formatters.aur_printer import AurPrinter
 from ahriman.application.formatters.configuration_printer import ConfigurationPrinter
 from ahriman.application.formatters.package_printer import PackagePrinter
 from ahriman.application.formatters.status_printer import StatusPrinter
+from ahriman.application.formatters.string_printer import StringPrinter
 from ahriman.application.formatters.update_printer import UpdatePrinter
 from ahriman.models.build_status import BuildStatus
 from ahriman.models.package import Package
@@ -46,6 +47,15 @@ def status_printer() -> StatusPrinter:
     :return: build status printer test instance
     """
     return StatusPrinter(BuildStatus())
+
+
+@pytest.fixture
+def string_printer() -> StringPrinter:
+    """
+    fixture for any string printer
+    :return: any string printer test instance
+    """
+    return StringPrinter("hello, world")
 
 
 @pytest.fixture

--- a/tests/ahriman/application/formatters/test_string_printer.py
+++ b/tests/ahriman/application/formatters/test_string_printer.py
@@ -1,0 +1,15 @@
+from ahriman.application.formatters.string_printer import StringPrinter
+
+
+def test_properties(string_printer: StringPrinter) -> None:
+    """
+    must return empty properties list
+    """
+    assert not string_printer.properties()
+
+
+def test_title(string_printer: StringPrinter) -> None:
+    """
+    must return non empty title
+    """
+    assert string_printer.title() is not None

--- a/tests/ahriman/core/repository/test_repository.py
+++ b/tests/ahriman/core/repository/test_repository.py
@@ -5,8 +5,8 @@ from ahriman.core.repository import Repository
 from ahriman.models.package import Package
 
 
-def test_packages(package_ahriman: Package, package_python_schedule: Package,
-                  repository: Repository, mocker: MockerFixture) -> None:
+def test_load_archives(package_ahriman: Package, package_python_schedule: Package,
+                       repository: Repository, mocker: MockerFixture) -> None:
     """
     must return all packages grouped by package base
     """
@@ -17,12 +17,9 @@ def test_packages(package_ahriman: Package, package_python_schedule: Package,
                 packages={package: props})
         for package, props in package_python_schedule.packages.items()
     ] + [package_ahriman]
-
-    mocker.patch("pathlib.Path.iterdir",
-                 return_value=[Path("a.pkg.tar.xz"), Path("b.pkg.tar.xz"), Path("c.pkg.tar.xz")])
     mocker.patch("ahriman.models.package.Package.load", side_effect=single_packages)
 
-    packages = repository.packages()
+    packages = repository.load_archives([Path("a.pkg.tar.xz"), Path("b.pkg.tar.xz"), Path("c.pkg.tar.xz")])
     assert len(packages) == 2
     assert {package.base for package in packages} == {package_ahriman.base, package_python_schedule.base}
 
@@ -33,21 +30,48 @@ def test_packages(package_ahriman: Package, package_python_schedule: Package,
     assert set(archives) == expected
 
 
-def test_packages_failed(repository: Repository, mocker: MockerFixture) -> None:
+def test_load_archives_failed(repository: Repository, mocker: MockerFixture) -> None:
     """
     must skip packages which cannot be loaded
     """
-    mocker.patch("pathlib.Path.iterdir", return_value=[Path("a.pkg.tar.xz")])
     mocker.patch("ahriman.models.package.Package.load", side_effect=Exception())
-    assert not repository.packages()
+    assert not repository.load_archives([Path("a.pkg.tar.xz")])
 
 
-def test_packages_not_package(repository: Repository, mocker: MockerFixture) -> None:
+def test_load_archives_not_package(repository: Repository) -> None:
     """
     must skip not packages from iteration
     """
-    mocker.patch("pathlib.Path.iterdir", return_value=[Path("a.tar.xz")])
-    assert not repository.packages()
+    assert not repository.load_archives([Path("a.tar.xz")])
+
+
+def test_load_archives_different_version(repository: Repository, package_python_schedule: Package,
+                                         mocker: MockerFixture) -> None:
+    """
+    must load packages with different versions choosing maximal
+    """
+    single_packages = [
+        Package(base=package_python_schedule.base,
+                version=package_python_schedule.version,
+                aur_url=package_python_schedule.aur_url,
+                packages={package: props})
+        for package, props in package_python_schedule.packages.items()
+    ]
+    single_packages[0].version = "0.0.1-1"
+    mocker.patch("ahriman.models.package.Package.load", side_effect=single_packages)
+
+    packages = repository.load_archives([Path("a.pkg.tar.xz"), Path("b.pkg.tar.xz")])
+    assert len(packages) == 1
+    assert packages[0].version == package_python_schedule.version
+
+
+def test_packages(repository: Repository, mocker: MockerFixture) -> None:
+    """
+    must return repository packages
+    """
+    load_mock = mocker.patch("ahriman.core.repository.repository.Repository.load_archives")
+    repository.packages()
+    load_mock.assert_called_once()  # it uses filter object so we cannot verity argument list =/
 
 
 def test_packages_built(repository: Repository, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary

This feature handles case when versions are different for same package base and choosing the maximal from them. Also `remove-unknown` subcommand now checks each package differently instead of base checking.

Closes #43 

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
