### PR TITLE
Complete official repository support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ This package contains application (aka executable) related classes and everythin
 
 This package contains everything which is required for any time of application run and separated to several packages:
 
-* `ahriman.core.alpm` package controls pacman related functions. It provides wrappers for `pyalpm` library and safe calls for repository tools (`repo-add` and `repo-remove`).
+* `ahriman.core.alpm` package controls pacman related functions. It provides wrappers for `pyalpm` library and safe calls for repository tools (`repo-add` and `repo-remove`). Also this package contains `ahriman.core.alpm.remote` package which provides wrapper for remote sources (e.g. AUR RPC and official repositories RPC).
 * `ahriman.core.auth` package provides classes for authorization methods used by web mostly. Base class is `ahriman.core.auth.auth.Auth` which must be called by `load` method.
 * `ahriman.core.build_tools` is a package which provides wrapper for `devtools` commands.
 * `ahriman.core.database` is everything including data and schema migrations for database.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,6 @@ Base configuration settings.
 
 libalpm and AUR related configuration.
 
-* `aur_url` - base url for AUR, string, required.
 * `database` - path to pacman local database cache, string, required.
 * `repositories` - list of pacman repositories, space separated list of strings, required.
 * `root` - root for alpm library, string, required.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -113,6 +113,14 @@ Well it is supported also.
 
 The last command will calculate diff from current tree to the `HEAD` and will store it locally. Patches will be applied on any package actions (e.g. it can be used for dependency management).
 
+### Hey, I would like to rebuild the official repository package
+
+So it is the same as adding any other package, but due to restrictions you must specify source explicitly, e.g.:
+
+```shell
+sudo -u ahriman ahriman package-add pacmann -s repository
+```
+
 ### Package build fails because it cannot validate PGP signature of source files
 
 TL;DR

--- a/package/share/ahriman/settings/ahriman.ini
+++ b/package/share/ahriman/settings/ahriman.ini
@@ -4,7 +4,6 @@ logging = ahriman.ini.d/logging.ini
 database = /var/lib/ahriman/ahriman.db
 
 [alpm]
-aur_url = https://aur.archlinux.org
 database = /var/lib/pacman
 repositories = core extra community multilib
 root = /

--- a/package/share/ahriman/templates/build-status.jinja2
+++ b/package/share/ahriman/templates/build-status.jinja2
@@ -74,7 +74,7 @@
                     {% for package in packages %}
                         <tr data-package-base="{{ package.base }}">
                             <td data-checkbox="true"></td>
-                            <td><a href="{{ package.web_url }}" title="{{ package.base }}">{{ package.base }}</a></td>
+                            <td>{% if package.web_url is not none %}<a href="{{ package.web_url }}" title="{{ package.base }}">{{ package.base }}</a>{% else %}{{ package.base }}{% endif %}</td>
                             <td>{{ package.version }}</td>
                             <td>{{ package.packages|join("<br>"|safe) }}</td>
                             <td>{{ package.groups|join("<br>"|safe) }}</td>

--- a/src/ahriman/application/application/application_repository.py
+++ b/src/ahriman/application/application/application_repository.py
@@ -128,14 +128,14 @@ class ApplicationRepository(ApplicationProperties):
             packages: List[str] = []
             for single in probe.packages:
                 try:
-                    _ = Package.from_aur(single, probe.aur_url)
+                    _ = Package.from_aur(single, self.repository.pacman)
                 except Exception:
                     packages.append(single)
             return packages
 
         def unknown_local(probe: Package) -> List[str]:
             cache_dir = self.repository.paths.cache_for(probe.base)
-            local = Package.from_build(cache_dir, probe.aur_url)
+            local = Package.from_build(cache_dir)
             packages = set(probe.packages.keys()).difference(local.packages.keys())
             return list(packages)
 

--- a/src/ahriman/application/handlers/patch.py
+++ b/src/ahriman/application/handlers/patch.py
@@ -29,7 +29,6 @@ from ahriman.core.configuration import Configuration
 from ahriman.core.formatters.string_printer import StringPrinter
 from ahriman.models.action import Action
 from ahriman.models.package import Package
-from ahriman.models.package_source import PackageSource
 
 
 class Patch(Handler):
@@ -57,21 +56,20 @@ class Patch(Handler):
         elif args.action == Action.Remove:
             Patch.patch_set_remove(application, args.package)
         elif args.action == Action.Update:
-            Patch.patch_set_create(application, args.package, args.track)
+            Patch.patch_set_create(application, Path(args.package), args.track)
 
     @staticmethod
-    def patch_set_create(application: Application, sources_dir: str, track: List[str]) -> None:
+    def patch_set_create(application: Application, sources_dir: Path, track: List[str]) -> None:
         """
         create patch set for the package base
 
         Args:
             application(Application): application instance
-            sources_dir(str): path to directory with the package sources
+            sources_dir(Path): path to directory with the package sources
             track(List[str]): track files which match the glob before creating the patch
         """
-        package = Package.load(sources_dir, PackageSource.Local, application.repository.pacman,
-                               application.repository.aur_url)
-        patch = Sources.patch_create(Path(sources_dir), *track)
+        package = Package.from_build(sources_dir)
+        patch = Sources.patch_create(sources_dir, *track)
         application.database.patches_insert(package.base, patch)
 
     @staticmethod

--- a/src/ahriman/application/handlers/search.py
+++ b/src/ahriman/application/handlers/search.py
@@ -22,6 +22,7 @@ import argparse
 from dataclasses import fields
 from typing import Callable, Iterable, List, Tuple, Type
 
+from ahriman.application.application import Application
 from ahriman.application.handlers.handler import Handler
 from ahriman.core.alpm.remote.aur import AUR
 from ahriman.core.alpm.remote.official import Official
@@ -55,8 +56,10 @@ class Search(Handler):
             no_report(bool): force disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        official_packages_list = Official.multisearch(*args.search)
-        aur_packages_list = AUR.multisearch(*args.search)
+        application = Application(architecture, configuration, no_report, unsafe)
+
+        official_packages_list = Official.multisearch(*args.search, pacman=application.repository.pacman)
+        aur_packages_list = AUR.multisearch(*args.search, pacman=application.repository.pacman)
         Search.check_if_empty(args.exit_code, not official_packages_list and not aur_packages_list)
 
         for packages_list in (official_packages_list, aur_packages_list):

--- a/src/ahriman/core/alpm/remote/official_syncdb.py
+++ b/src/ahriman/core/alpm/remote/official_syncdb.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2021-2022 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from ahriman.core.alpm.pacman import Pacman
+from ahriman.core.alpm.remote.official import Official
+from ahriman.models.aur_package import AURPackage
+
+
+class OfficialSyncdb(Official):
+    """
+    official repository wrapper based on synchronized databases.
+
+    Despite the fact that official repository provides an API for the interaction according to the comment in issue
+    https://github.com/arcan1s/ahriman/pull/59#issuecomment-1106412297 we might face rate limits while requesting
+    updates.
+
+    This approach also has limitations, because we don't require superuser rights (neither going to download database
+    separately), the database file might be outdated and must be handled manually (or kind of). This behaviour might be
+    changed in the future.
+
+    Still we leave search function based on the official repositories RPC.
+    """
+
+    def package_info(self, package_name: str, *, pacman: Pacman) -> AURPackage:
+        """
+        get package info by its name
+
+        Args:
+            package_name(str): package name to search
+            pacman(Pacman): alpm wrapper instance
+
+        Returns:
+            AURPackage: package which match the package name
+        """
+        return next(AURPackage.from_pacman(package) for package in pacman.get(package_name))

--- a/src/ahriman/core/build_tools/task.py
+++ b/src/ahriman/core/build_tools/task.py
@@ -107,4 +107,4 @@ class Task:
         if self.paths.cache_for(self.package.base).is_dir():
             # no need to clone whole repository, just copy from cache first
             shutil.copytree(self.paths.cache_for(self.package.base), path, dirs_exist_ok=True)
-        Sources.load(path, self.package.git_url, database.patches_get(self.package.base))
+        Sources.load(path, self.package.remote, database.patches_get(self.package.base))

--- a/src/ahriman/core/database/data/__init__.py
+++ b/src/ahriman/core/database/data/__init__.py
@@ -20,6 +20,7 @@
 from sqlite3 import Connection
 
 from ahriman.core.configuration import Configuration
+from ahriman.core.database.data.package_remotes import migrate_package_remotes
 from ahriman.core.database.data.package_statuses import migrate_package_statuses
 from ahriman.core.database.data.patches import migrate_patches
 from ahriman.core.database.data.users import migrate_users_data
@@ -43,3 +44,5 @@ def migrate_data(
         migrate_package_statuses(connection, repository_paths)
         migrate_patches(connection, repository_paths)
         migrate_users_data(connection, configuration)
+    if result.old_version <= 1:
+        migrate_package_remotes(connection, repository_paths)

--- a/src/ahriman/core/database/data/package_remotes.py
+++ b/src/ahriman/core/database/data/package_remotes.py
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2021-2022 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from sqlite3 import Connection
+
+from ahriman.models.package_source import PackageSource
+from ahriman.models.remote_source import RemoteSource
+from ahriman.models.repository_paths import RepositoryPaths
+
+
+# pylint: disable=protected-access
+def migrate_package_remotes(connection: Connection, paths: RepositoryPaths) -> None:
+    """
+    perform migration for package remote sources
+
+    Args:
+        connection(Connection): database connection
+        paths(RepositoryPaths): repository paths instance
+    """
+    from ahriman.core.database.operations.package_operations import PackageOperations
+
+    def insert_remote(base: str, remote: RemoteSource) -> None:
+        connection.execute(
+            """
+            update package_bases set
+            branch = :branch, git_url = :git_url, path = :path,
+            web_url = :web_url, source = :source
+            where package_base = :package_base
+            """,
+            dict(
+                package_base=base,
+                branch=remote.branch, git_url=remote.git_url, path=remote.path,
+                web_url=remote.web_url, source=remote.source
+            )
+        )
+
+    packages = PackageOperations._packages_get_select_package_bases(connection)
+    for package_base, package in packages.items():
+        local_cache = paths.cache_for(package_base)
+        if local_cache.exists() and not package.is_vcs:
+            continue  # skip packages which are not VCS and with local cache
+        remote_source = RemoteSource.from_remote(PackageSource.AUR, package_base, "aur")
+        if remote_source is None:
+            continue  # should never happen
+        insert_remote(package_base, remote_source)

--- a/src/ahriman/core/database/data/package_statuses.py
+++ b/src/ahriman/core/database/data/package_statuses.py
@@ -42,7 +42,7 @@ def migrate_package_statuses(connection: Connection, paths: RepositoryPaths) -> 
             values
             (:package_base, :version, :aur_url)
             """,
-            dict(package_base=metadata.base, version=metadata.version, aur_url=metadata.aur_url))
+            dict(package_base=metadata.base, version=metadata.version, aur_url=""))
         connection.execute(
             """
             insert into package_statuses

--- a/src/ahriman/core/database/migrations/m001_package_source.py
+++ b/src/ahriman/core/database/migrations/m001_package_source.py
@@ -17,19 +17,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from enum import Enum
 
-
-class Action(str, Enum):
+steps = [
     """
-    base action enumeration
-
-    Attributes:
-        List(Action): (class attribute) list available values
-        Remove(Action): (class attribute) remove everything from local storage
-        Update(Action): (class attribute) update local storage or add to
+    alter table package_bases add column branch text
+    """,
     """
-
-    List = "list"
-    Remove = "remove"
-    Update = "update"
+    alter table package_bases add column git_url text
+    """,
+    """
+    alter table package_bases add column path text
+    """,
+    """
+    alter table package_bases add column web_url text
+    """,
+    """
+    alter table package_bases add column source text
+    """,
+    """
+    alter table package_bases drop column aur_url
+    """,
+]

--- a/src/ahriman/core/database/sqlite.py
+++ b/src/ahriman/core/database/sqlite.py
@@ -81,5 +81,5 @@ class SQLite(AuthOperations, BuildOperations, PackageOperations, PatchOperations
 
         paths = configuration.repository_paths
 
-        self.with_connection(lambda conn: Migrations.migrate(conn, configuration))
+        self.with_connection(lambda connection: Migrations.migrate(connection, configuration))
         paths.chown(self.path)

--- a/src/ahriman/core/repository/repository_properties.py
+++ b/src/ahriman/core/repository/repository_properties.py
@@ -35,7 +35,6 @@ class RepositoryProperties:
 
     Attributes:
         architecture(str): repository architecture
-        aur_url(str): base AUR url
         configuration(Configuration): configuration instance
         database(SQLite): database instance
         ignore_list(List[str]): package bases which will be ignored during auto updates
@@ -65,7 +64,6 @@ class RepositoryProperties:
         self.configuration = configuration
         self.database = database
 
-        self.aur_url = configuration.get("alpm", "aur_url")
         self.name = configuration.get("repository", "name")
 
         self.paths = configuration.repository_paths

--- a/src/ahriman/core/tree.py
+++ b/src/ahriman/core/tree.py
@@ -70,7 +70,7 @@ class Leaf:
             Leaf: loaded class
         """
         with tmpdir() as clone_dir:
-            Sources.load(clone_dir, package.git_url, database.patches_get(package.base))
+            Sources.load(clone_dir, package.remote, database.patches_get(package.base))
             dependencies = Package.dependencies(clone_dir)
         return cls(package, dependencies)
 

--- a/src/ahriman/models/auth_settings.py
+++ b/src/ahriman/models/auth_settings.py
@@ -23,7 +23,7 @@ from enum import Enum
 from typing import Type
 
 
-class AuthSettings(Enum):
+class AuthSettings(str, Enum):
     """
     web authorization type
 

--- a/src/ahriman/models/build_status.py
+++ b/src/ahriman/models/build_status.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, Type
 from ahriman.core.util import filter_json, pretty_datetime
 
 
-class BuildStatusEnum(Enum):
+class BuildStatusEnum(str, Enum):
     """
     build status enumeration
 

--- a/src/ahriman/models/package_source.py
+++ b/src/ahriman/models/package_source.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse
 from ahriman.core.util import package_like
 
 
-class PackageSource(Enum):
+class PackageSource(str, Enum):
     """
     package source for addition enumeration
 

--- a/src/ahriman/models/remote_source.py
+++ b/src/ahriman/models/remote_source.py
@@ -1,0 +1,124 @@
+#
+# Copyright (c) 2021-2022 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any, Dict, Optional, Type
+
+from ahriman.core.util import filter_json
+from ahriman.models.package_source import PackageSource
+
+
+@dataclass
+class RemoteSource:
+    """
+    remote package source properties
+
+    Attributes:
+        branch(str): branch of the git repository
+        git_url(str): url of the git repository
+        path(str): path to directory with PKGBUILD inside the git repository
+        source(PackageSource): package source pointer used by some parsers
+        web_url(str): url of the package in the web interface
+    """
+
+    git_url: str
+    web_url: str
+    path: str
+    branch: str
+    source: PackageSource
+
+    def __post_init__(self) -> None:
+        """
+        convert source to enum type
+        """
+        self.source = PackageSource(self.source)
+
+    @property
+    def pkgbuild_dir(self) -> Path:
+        """
+        get path to directory with package sources (PKGBUILD etc)
+
+        Returns:
+            Path: path to directory with package sources based on settings
+        """
+        return Path(self.path)
+
+    @classmethod
+    def from_json(cls: Type[RemoteSource], dump: Dict[str, Any]) -> Optional[RemoteSource]:
+        """
+        construct remote source from the json dump (or database row)
+
+        Args:
+            dump(Dict[str, Any]): json dump body
+
+        Returns:
+            Optional[RemoteSource]: remote source
+        """
+        # filter to only known fields
+        known_fields = [pair.name for pair in fields(cls)]
+        dump = filter_json(dump, known_fields)
+        if dump:
+            return cls(**dump)
+        return None
+
+    @classmethod
+    def from_remote(cls: Type[RemoteSource], source: PackageSource, package_base: str,
+                    repository: str) -> Optional[RemoteSource]:
+        """
+        generate remote source from the package base
+
+        Args:
+            source(PackageSource): source of the package
+            package_base(str): package base
+            repository(str): repository name
+
+        Returns:
+            Optional[RemoteSource]: generated remote source if any, None otherwise
+        """
+        if source == PackageSource.AUR:
+            from ahriman.core.alpm.remote.aur import AUR
+            return RemoteSource(
+                git_url=AUR.remote_git_url(package_base, repository),
+                web_url=AUR.remote_web_url(package_base),
+                path=".",
+                branch="master",
+                source=source,
+            )
+        if source == PackageSource.Repository:
+            from ahriman.core.alpm.remote.official import Official
+            return RemoteSource(
+                git_url=Official.remote_git_url(package_base, repository),
+                web_url=Official.remote_web_url(package_base),
+                path="trunk",
+                branch=f"packages/{package_base}",
+                source=source,
+            )
+        return None
+
+    def view(self) -> Dict[str, Any]:
+        """
+        generate json package remote view
+
+        Returns:
+            Dict[str, Any]: json-friendly dictionary
+        """
+        return asdict(self)

--- a/src/ahriman/models/report_settings.py
+++ b/src/ahriman/models/report_settings.py
@@ -23,7 +23,7 @@ from enum import Enum
 from typing import Type
 
 
-class ReportSettings(Enum):
+class ReportSettings(str, Enum):
     """
     report targets enumeration
 

--- a/src/ahriman/models/sign_settings.py
+++ b/src/ahriman/models/sign_settings.py
@@ -23,7 +23,7 @@ from enum import Enum
 from typing import Type
 
 
-class SignSettings(Enum):
+class SignSettings(str, Enum):
     """
     sign targets enumeration
 

--- a/src/ahriman/models/smtp_ssl_settings.py
+++ b/src/ahriman/models/smtp_ssl_settings.py
@@ -23,7 +23,7 @@ from enum import Enum
 from typing import Type
 
 
-class SmtpSSLSettings(Enum):
+class SmtpSSLSettings(str, Enum):
     """
     SMTP SSL mode enumeration
 

--- a/src/ahriman/models/upload_settings.py
+++ b/src/ahriman/models/upload_settings.py
@@ -23,7 +23,7 @@ from enum import Enum
 from typing import Type
 
 
-class UploadSettings(Enum):
+class UploadSettings(str, Enum):
     """
     remote synchronization targets enumeration
 

--- a/src/ahriman/models/user_access.py
+++ b/src/ahriman/models/user_access.py
@@ -20,7 +20,7 @@
 from enum import Enum
 
 
-class UserAccess(Enum):
+class UserAccess(str, Enum):
     """
     web user access enumeration
 

--- a/src/ahriman/web/views/index.py
+++ b/src/ahriman/web/views/index.py
@@ -86,7 +86,7 @@ class IndexView(BaseView):
                 "status_color": status.status.bootstrap_color(),
                 "timestamp": pretty_datetime(status.timestamp),
                 "version": package.version,
-                "web_url": package.web_url,
+                "web_url": package.remote.web_url if package.remote is not None else None,
             } for package, status in sorted(self.service.packages, key=lambda item: item[0].base)
         ]
         service = {

--- a/src/ahriman/web/views/service/search.py
+++ b/src/ahriman/web/views/service/search.py
@@ -50,7 +50,7 @@ class SearchView(BaseView):
             HTTPNotFound: if no packages found
         """
         search: List[str] = self.request.query.getall("for", default=[])
-        packages = AUR.multisearch(*search)
+        packages = AUR.multisearch(*search, pacman=self.service.repository.pacman)
         if not packages:
             raise HTTPNotFound(reason=f"No packages found for terms: {search}")
 

--- a/tests/ahriman/application/application/test_application_repository.py
+++ b/tests/ahriman/application/application/test_application_repository.py
@@ -14,7 +14,7 @@ def test_finalize(application_repository: ApplicationRepository) -> None:
     must raise NotImplemented for missing finalize method
     """
     with pytest.raises(NotImplementedError):
-        application_repository._finalize([])
+        application_repository._finalize(Result())
 
 
 def test_clean_cache(application_repository: ApplicationRepository, mocker: MockerFixture) -> None:
@@ -58,8 +58,8 @@ def test_report(application_repository: ApplicationRepository, mocker: MockerFix
     must generate report
     """
     executor_mock = mocker.patch("ahriman.core.repository.executor.Executor.process_report")
-    application_repository.report(["a"], [])
-    executor_mock.assert_called_once_with(["a"], [])
+    application_repository.report(["a"], Result())
+    executor_mock.assert_called_once_with(["a"], Result())
 
 
 def test_sign(application_repository: ApplicationRepository, package_ahriman: Package, package_python_schedule: Package,
@@ -179,7 +179,6 @@ def test_update(application_repository: ApplicationRepository, package_ahriman: 
 
     mocker.patch("ahriman.core.tree.Tree.load", return_value=tree)
     mocker.patch("ahriman.core.repository.repository.Repository.packages_built", return_value=paths)
-    mocker.patch("ahriman.models.package.Package.load", return_value=package_ahriman)
     build_mock = mocker.patch("ahriman.core.repository.executor.Executor.process_build", return_value=result)
     update_mock = mocker.patch("ahriman.core.repository.executor.Executor.process_update", return_value=result)
     finalize_mock = mocker.patch(
@@ -201,7 +200,6 @@ def test_update_empty(application_repository: ApplicationRepository, package_ahr
 
     mocker.patch("ahriman.core.tree.Tree.load", return_value=tree)
     mocker.patch("ahriman.core.repository.repository.Repository.packages_built", return_value=[])
-    mocker.patch("ahriman.models.package.Package.load", return_value=package_ahriman)
     mocker.patch("ahriman.core.repository.executor.Executor.process_build")
     update_mock = mocker.patch("ahriman.core.repository.executor.Executor.process_update")
 

--- a/tests/ahriman/application/handlers/test_handler_patch.py
+++ b/tests/ahriman/application/handlers/test_handler_patch.py
@@ -1,6 +1,7 @@
 import argparse
 import pytest
 
+from pathlib import Path
 from pytest_mock import MockerFixture
 
 from ahriman.application.application import Application
@@ -37,7 +38,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     application_mock = mocker.patch("ahriman.application.handlers.patch.Patch.patch_set_create")
 
     Patch.run(args, "x86_64", configuration, True, False)
-    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, args.track)
+    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), Path(args.package), args.track)
 
 
 def test_run_list(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
@@ -96,11 +97,11 @@ def test_patch_set_create(application: Application, package_ahriman: Package, mo
     must create patch set for the package
     """
     mocker.patch("pathlib.Path.mkdir")
-    mocker.patch("ahriman.models.package.Package.load", return_value=package_ahriman)
+    mocker.patch("ahriman.models.package.Package.from_build", return_value=package_ahriman)
     mocker.patch("ahriman.core.build_tools.sources.Sources.patch_create", return_value="patch")
     create_mock = mocker.patch("ahriman.core.database.sqlite.SQLite.patches_insert")
 
-    Patch.patch_set_create(application, "path", ["*.patch"])
+    Patch.patch_set_create(application, Path("path"), ["*.patch"])
     create_mock.assert_called_once_with(package_ahriman.base, "patch")
 
 

--- a/tests/ahriman/application/handlers/test_handler_search.py
+++ b/tests/ahriman/application/handlers/test_handler_search.py
@@ -34,6 +34,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, aur_package
     must run command
     """
     args = _default_args(args)
+    mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     aur_search_mock = mocker.patch("ahriman.core.alpm.remote.aur.AUR.multisearch", return_value=[aur_package_ahriman])
     official_search_mock = mocker.patch("ahriman.core.alpm.remote.official.Official.multisearch",
                                         return_value=[aur_package_ahriman])
@@ -41,8 +42,8 @@ def test_run(args: argparse.Namespace, configuration: Configuration, aur_package
     print_mock = mocker.patch("ahriman.core.formatters.printer.Printer.print")
 
     Search.run(args, "x86_64", configuration, True, False)
-    aur_search_mock.assert_called_once_with("ahriman")
-    official_search_mock.assert_called_once_with("ahriman")
+    aur_search_mock.assert_called_once_with("ahriman", pacman=pytest.helpers.anyvar(int))
+    official_search_mock.assert_called_once_with("ahriman", pacman=pytest.helpers.anyvar(int))
     check_mock.assert_called_once_with(False, False)
     print_mock.assert_has_calls([mock.call(False), mock.call(False)])
 
@@ -56,6 +57,7 @@ def test_run_empty_exception(args: argparse.Namespace, configuration: Configurat
     mocker.patch("ahriman.core.alpm.remote.aur.AUR.multisearch", return_value=[])
     mocker.patch("ahriman.core.alpm.remote.official.Official.multisearch", return_value=[])
     mocker.patch("ahriman.core.formatters.printer.Printer.print")
+    mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     check_mock = mocker.patch("ahriman.application.handlers.handler.Handler.check_if_empty")
 
     Search.run(args, "x86_64", configuration, True, False)
@@ -70,6 +72,7 @@ def test_run_sort(args: argparse.Namespace, configuration: Configuration, aur_pa
     args = _default_args(args)
     mocker.patch("ahriman.core.alpm.remote.aur.AUR.multisearch", return_value=[aur_package_ahriman])
     mocker.patch("ahriman.core.alpm.remote.official.Official.multisearch", return_value=[])
+    mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     sort_mock = mocker.patch("ahriman.application.handlers.search.Search.sort")
 
     Search.run(args, "x86_64", configuration, True, False)
@@ -88,6 +91,7 @@ def test_run_sort_by(args: argparse.Namespace, configuration: Configuration, aur
     args.sort_by = "field"
     mocker.patch("ahriman.core.alpm.remote.aur.AUR.multisearch", return_value=[aur_package_ahriman])
     mocker.patch("ahriman.core.alpm.remote.official.Official.multisearch", return_value=[])
+    mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     sort_mock = mocker.patch("ahriman.application.handlers.search.Search.sort")
 
     Search.run(args, "x86_64", configuration, True, False)

--- a/tests/ahriman/conftest.py
+++ b/tests/ahriman/conftest.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 from typing import Any, Dict, Type, TypeVar
 from unittest.mock import MagicMock
 
+from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.auth.auth import Auth
 from ahriman.core.configuration import Configuration
 from ahriman.core.database.sqlite import SQLite
@@ -15,6 +16,8 @@ from ahriman.models.aur_package import AURPackage
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.package import Package
 from ahriman.models.package_description import PackageDescription
+from ahriman.models.package_source import PackageSource
+from ahriman.models.remote_source import RemoteSource
 from ahriman.models.repository_paths import RepositoryPaths
 from ahriman.models.result import Result
 from ahriman.models.user import User
@@ -101,8 +104,8 @@ def aur_package_ahriman() -> AURPackage:
         description="ArcH Linux ReposItory MANager",
         num_votes=0,
         popularity=0,
-        first_submitted=datetime.datetime(2021, 4, 9, 22, 44, 45),
-        last_modified=datetime.datetime(2021, 12, 25, 23, 11, 11),
+        first_submitted=datetime.datetime.utcfromtimestamp(1618008285),
+        last_modified=datetime.datetime.utcfromtimestamp(1640473871),
         url_path="/cgit/aur.git/snapshot/ahriman.tar.gz",
         url="https://github.com/arcan1s/ahriman",
         out_of_date=None,
@@ -155,13 +158,14 @@ def aur_package_akonadi() -> AURPackage:
         version="21.12.3-2",
         description="PIM layer, which provides an asynchronous API to access all kind of PIM data",
         num_votes=0,
-        popularity=0,
-        first_submitted=datetime.datetime(1970, 1, 1, 0, 0, 0),
-        last_modified=datetime.datetime(2022, 3, 6, 8, 39, 50, 610000),
+        popularity=0.0,
+        first_submitted=datetime.datetime.utcfromtimestamp(0),
+        last_modified=datetime.datetime.utcfromtimestamp(1646555990.610),
         url_path="",
         url="https://kontact.kde.org",
         out_of_date=None,
         maintainer="felixonmars",
+        repository="extra",
         depends=[
             "libakonadi",
             "mariadb",
@@ -245,7 +249,7 @@ def package_ahriman(package_description_ahriman: PackageDescription) -> Package:
     return Package(
         base="ahriman",
         version="1.7.0-1",
-        aur_url="https://aur.archlinux.org",
+        remote=RemoteSource.from_remote(PackageSource.AUR, "ahriman", "aur"),
         packages=packages)
 
 
@@ -270,7 +274,7 @@ def package_python_schedule(
     return Package(
         base="python-schedule",
         version="1.0.0-2",
-        aur_url="https://aur.archlinux.org",
+        remote=RemoteSource.from_remote(PackageSource.AUR, "python-schedule", "aur"),
         packages=packages)
 
 
@@ -342,6 +346,34 @@ def package_description_python2_schedule() -> PackageDescription:
         installed_size=4200002,
         licenses=["MIT"],
         url="https://github.com/dbader/schedule")
+
+
+@pytest.fixture
+def pacman(configuration: Configuration) -> Pacman:
+    """
+    fixture for pacman wrapper
+
+    Args:
+        configuration(Configuration): configuration fixture
+
+    Returns:
+        Pacman: pacman wrapper test instance
+    """
+    return Pacman(configuration)
+
+
+@pytest.fixture
+def remote_source(package_ahriman: Package) -> RemoteSource:
+    """
+    remote source fixture
+
+    Args:
+        package_ahriman(Package): package fixture
+
+    Returns:
+        RemoteSource: remote source test instance
+    """
+    return RemoteSource.from_remote(PackageSource.AUR, "ahriman", "aur")
 
 
 @pytest.fixture

--- a/tests/ahriman/core/alpm/remote/conftest.py
+++ b/tests/ahriman/core/alpm/remote/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 from ahriman.core.alpm.remote.aur import AUR
 from ahriman.core.alpm.remote.official import Official
+from ahriman.core.alpm.remote.official_syncdb import OfficialSyncdb
 from ahriman.core.alpm.remote.remote import Remote
 
 
@@ -25,6 +26,17 @@ def official() -> Official:
         Official: official repository helper instance
     """
     return Official()
+
+
+@pytest.fixture
+def official_syncdb() -> OfficialSyncdb:
+    """
+    official repository fixture with database processing
+
+    Returns:
+        OfficialSyncdb: official repository with database processing helper instance
+    """
+    return OfficialSyncdb()
 
 
 @pytest.fixture

--- a/tests/ahriman/core/alpm/remote/test_aur.py
+++ b/tests/ahriman/core/alpm/remote/test_aur.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pytest_mock import MockerFixture
 from unittest.mock import MagicMock
 
+from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.remote.aur import AUR
 from ahriman.core.exceptions import InvalidPackageInfo
 from ahriman.models.aur_package import AURPackage
@@ -47,6 +48,23 @@ def test_parse_response_unknown_error() -> None:
     """
     with pytest.raises(InvalidPackageInfo, match="Unknown API error"):
         AUR.parse_response({"type": "error"})
+
+
+def test_remote_git_url(aur_package_ahriman: AURPackage) -> None:
+    """
+    must generate package git url
+    """
+    git_url = AUR.remote_git_url(aur_package_ahriman.package_base, aur_package_ahriman.repository)
+    assert git_url.endswith(".git")
+    assert git_url.startswith(AUR.DEFAULT_AUR_URL)
+
+
+def test_remote_web_url(aur_package_ahriman: AURPackage) -> None:
+    """
+    must generate package git url
+    """
+    web_url = AUR.remote_web_url(aur_package_ahriman.package_base)
+    assert web_url.startswith(AUR.DEFAULT_AUR_URL)
 
 
 def test_make_request(aur: AUR, aur_package_ahriman: AURPackage,
@@ -109,19 +127,19 @@ def test_make_request_failed_http_error(aur: AUR, mocker: MockerFixture) -> None
         aur.make_request("info", "ahriman")
 
 
-def test_package_info(aur: AUR, aur_package_ahriman: AURPackage, mocker: MockerFixture) -> None:
+def test_package_info(aur: AUR, aur_package_ahriman: AURPackage, pacman: Pacman, mocker: MockerFixture) -> None:
     """
     must make request for info
     """
     request_mock = mocker.patch("ahriman.core.alpm.remote.aur.AUR.make_request", return_value=[aur_package_ahriman])
-    assert aur.package_info(aur_package_ahriman.name) == aur_package_ahriman
+    assert aur.package_info(aur_package_ahriman.name, pacman=pacman) == aur_package_ahriman
     request_mock.assert_called_once_with("info", aur_package_ahriman.name)
 
 
-def test_package_search(aur: AUR, aur_package_ahriman: AURPackage, mocker: MockerFixture) -> None:
+def test_package_search(aur: AUR, aur_package_ahriman: AURPackage, pacman: Pacman, mocker: MockerFixture) -> None:
     """
     must make request for search
     """
     request_mock = mocker.patch("ahriman.core.alpm.remote.aur.AUR.make_request", return_value=[aur_package_ahriman])
-    assert aur.package_search(aur_package_ahriman.name) == [aur_package_ahriman]
+    assert aur.package_search(aur_package_ahriman.name, pacman=pacman) == [aur_package_ahriman]
     request_mock.assert_called_once_with("search", aur_package_ahriman.name, by="name-desc")

--- a/tests/ahriman/core/alpm/remote/test_official.py
+++ b/tests/ahriman/core/alpm/remote/test_official.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pytest_mock import MockerFixture
 from unittest.mock import MagicMock
 
+from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.remote.official import Official
 from ahriman.core.exceptions import InvalidPackageInfo
 from ahriman.models.aur_package import AURPackage
@@ -41,6 +42,38 @@ def test_parse_response_unknown_error(resource_path_root: Path) -> None:
         Official.parse_response(json.loads(response))
 
 
+def test_remote_git_url(aur_package_akonadi: AURPackage) -> None:
+    """
+    must generate package git url for core packages
+    """
+    git_urls = [
+        Official.remote_git_url(aur_package_akonadi.package_base, repository)
+        for repository in ("core", "extra", "Core", "Extra")
+    ]
+    assert all(git_url.endswith("svntogit-packages.git") for git_url in git_urls)
+    assert len(set(git_urls)) == 1
+
+
+def test_remote_git_url_community(aur_package_akonadi: AURPackage) -> None:
+    """
+    must generate package git url for core packages
+    """
+    git_urls = [
+        Official.remote_git_url(aur_package_akonadi.package_base, repository)
+        for repository in ("community", "multilib", "Community", "Multilib")
+    ]
+    assert all(git_url.endswith("svntogit-community.git") for git_url in git_urls)
+    assert len(set(git_urls)) == 1
+
+
+def test_remote_web_url(aur_package_akonadi: AURPackage) -> None:
+    """
+    must generate package git url
+    """
+    web_url = Official.remote_web_url(aur_package_akonadi.package_base)
+    assert web_url.startswith(Official.DEFAULT_ARCHLINUX_URL)
+
+
 def test_make_request(official: Official, aur_package_akonadi: AURPackage,
                       mocker: MockerFixture, resource_path_root: Path) -> None:
     """
@@ -51,7 +84,8 @@ def test_make_request(official: Official, aur_package_akonadi: AURPackage,
     request_mock = mocker.patch("requests.get", return_value=response_mock)
 
     assert official.make_request("akonadi", by="q") == [aur_package_akonadi]
-    request_mock.assert_called_once_with("https://archlinux.org/packages/search/json", params={"q": ("akonadi",)})
+    request_mock.assert_called_once_with("https://archlinux.org/packages/search/json",
+                                         params={"q": ("akonadi",), "repo": Official.DEFAULT_SEARCH_REPOSITORIES})
 
 
 def test_make_request_failed(official: Official, mocker: MockerFixture) -> None:
@@ -72,21 +106,23 @@ def test_make_request_failed_http_error(official: Official, mocker: MockerFixtur
         official.make_request("akonadi", by="q")
 
 
-def test_package_info(official: Official, aur_package_akonadi: AURPackage, mocker: MockerFixture) -> None:
+def test_package_info(official: Official, aur_package_akonadi: AURPackage, pacman: Pacman,
+                      mocker: MockerFixture) -> None:
     """
     must make request for info
     """
     request_mock = mocker.patch("ahriman.core.alpm.remote.official.Official.make_request",
                                 return_value=[aur_package_akonadi])
-    assert official.package_info(aur_package_akonadi.name) == aur_package_akonadi
+    assert official.package_info(aur_package_akonadi.name, pacman=pacman) == aur_package_akonadi
     request_mock.assert_called_once_with(aur_package_akonadi.name, by="name")
 
 
-def test_package_search(official: Official, aur_package_akonadi: AURPackage, mocker: MockerFixture) -> None:
+def test_package_search(official: Official, aur_package_akonadi: AURPackage, pacman: Pacman,
+                        mocker: MockerFixture) -> None:
     """
     must make request for search
     """
     request_mock = mocker.patch("ahriman.core.alpm.remote.official.Official.make_request",
                                 return_value=[aur_package_akonadi])
-    assert official.package_search(aur_package_akonadi.name) == [aur_package_akonadi]
+    assert official.package_search(aur_package_akonadi.name, pacman=pacman) == [aur_package_akonadi]
     request_mock.assert_called_once_with(aur_package_akonadi.name, by="q")

--- a/tests/ahriman/core/alpm/remote/test_official_syncdb.py
+++ b/tests/ahriman/core/alpm/remote/test_official_syncdb.py
@@ -1,0 +1,18 @@
+from pytest_mock import MockerFixture
+
+from ahriman.core.alpm.pacman import Pacman
+from ahriman.core.alpm.remote.official_syncdb import OfficialSyncdb
+from ahriman.models.aur_package import AURPackage
+
+
+def test_package_info(official_syncdb: OfficialSyncdb, aur_package_akonadi: AURPackage,
+                      pacman: Pacman, mocker: MockerFixture) -> None:
+    """
+    must return package info from the database
+    """
+    mocker.patch("ahriman.models.aur_package.AURPackage.from_pacman", return_value=aur_package_akonadi)
+    get_mock = mocker.patch("ahriman.core.alpm.pacman.Pacman.get", return_value=[aur_package_akonadi])
+
+    package = official_syncdb.package_info(aur_package_akonadi.name, pacman=pacman)
+    get_mock.assert_called_once_with(aur_package_akonadi.name)
+    assert package == aur_package_akonadi

--- a/tests/ahriman/core/alpm/remote/test_remote.py
+++ b/tests/ahriman/core/alpm/remote/test_remote.py
@@ -3,70 +3,87 @@ import pytest
 from pytest_mock import MockerFixture
 from unittest import mock
 
+from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.remote.remote import Remote
 from ahriman.models.aur_package import AURPackage
 
 
-def test_info(mocker: MockerFixture) -> None:
+def test_info(pacman: Pacman, mocker: MockerFixture) -> None:
     """
     must call info method
     """
     info_mock = mocker.patch("ahriman.core.alpm.remote.remote.Remote.package_info")
-    Remote.info("ahriman")
-    info_mock.assert_called_once_with("ahriman")
+    Remote.info("ahriman", pacman=pacman)
+    info_mock.assert_called_once_with("ahriman", pacman=pacman)
 
 
-def test_multisearch(aur_package_ahriman: AURPackage, mocker: MockerFixture) -> None:
+def test_multisearch(aur_package_ahriman: AURPackage, pacman: Pacman, mocker: MockerFixture) -> None:
     """
     must search in AUR with multiple words
     """
     terms = ["ahriman", "is", "cool"]
     search_mock = mocker.patch("ahriman.core.alpm.remote.remote.Remote.search", return_value=[aur_package_ahriman])
 
-    assert Remote.multisearch(*terms) == [aur_package_ahriman]
-    search_mock.assert_has_calls([mock.call("ahriman"), mock.call("cool")])
+    assert Remote.multisearch(*terms, pacman=pacman) == [aur_package_ahriman]
+    search_mock.assert_has_calls([mock.call("ahriman", pacman=pacman), mock.call("cool", pacman=pacman)])
 
 
-def test_multisearch_empty(mocker: MockerFixture) -> None:
+def test_multisearch_empty(pacman: Pacman, mocker: MockerFixture) -> None:
     """
     must return empty list if no long terms supplied
     """
     terms = ["it", "is"]
     search_mock = mocker.patch("ahriman.core.alpm.remote.remote.Remote.search")
 
-    assert Remote.multisearch(*terms) == []
+    assert Remote.multisearch(*terms, pacman=pacman) == []
     search_mock.assert_not_called()
 
 
-def test_multisearch_single(aur_package_ahriman: AURPackage, mocker: MockerFixture) -> None:
+def test_multisearch_single(aur_package_ahriman: AURPackage, pacman: Pacman, mocker: MockerFixture) -> None:
     """
     must search in AUR with one word
     """
     search_mock = mocker.patch("ahriman.core.alpm.remote.remote.Remote.search", return_value=[aur_package_ahriman])
-    assert Remote.multisearch("ahriman") == [aur_package_ahriman]
-    search_mock.assert_called_once_with("ahriman")
+    assert Remote.multisearch("ahriman", pacman=pacman) == [aur_package_ahriman]
+    search_mock.assert_called_once_with("ahriman", pacman=pacman)
 
 
-def test_search(mocker: MockerFixture) -> None:
+def test_remote_git_url(remote: Remote, pacman: Pacman) -> None:
+    """
+    must raise NotImplemented for missing remote git url
+    """
+    with pytest.raises(NotImplementedError):
+        remote.remote_git_url("package", "repositorys")
+
+
+def test_remote_web_url(remote: Remote, pacman: Pacman) -> None:
+    """
+    must raise NotImplemented for missing remote web url
+    """
+    with pytest.raises(NotImplementedError):
+        remote.remote_web_url("package")
+
+
+def test_search(pacman: Pacman, mocker: MockerFixture) -> None:
     """
     must call search method
     """
     search_mock = mocker.patch("ahriman.core.alpm.remote.remote.Remote.package_search")
-    Remote.search("ahriman")
-    search_mock.assert_called_once_with("ahriman")
+    Remote.search("ahriman", pacman=pacman)
+    search_mock.assert_called_once_with("ahriman", pacman=pacman)
 
 
-def test_package_info(remote: Remote) -> None:
+def test_package_info(remote: Remote, pacman: Pacman) -> None:
     """
     must raise NotImplemented for missing package info method
     """
     with pytest.raises(NotImplementedError):
-        remote.package_info("package")
+        remote.package_info("package", pacman=pacman)
 
 
-def test_package_search(remote: Remote) -> None:
+def test_package_search(remote: Remote, pacman: Pacman) -> None:
     """
     must raise NotImplemented for missing package search method
     """
     with pytest.raises(NotImplementedError):
-        remote.package_search("package")
+        remote.package_search("package", pacman=pacman)

--- a/tests/ahriman/core/alpm/test_pacman.py
+++ b/tests/ahriman/core/alpm/test_pacman.py
@@ -15,3 +15,17 @@ def test_all_packages_with_provides(pacman: Pacman) -> None:
     package list must contain provides packages
     """
     assert "sh" in pacman.all_packages()
+
+
+def test_get(pacman: Pacman) -> None:
+    """
+    must retrieve package
+    """
+    assert list(pacman.get("pacman"))
+
+
+def test_get_empty(pacman: Pacman) -> None:
+    """
+    must return empty packages list without exception
+    """
+    assert not list(pacman.get("some-random-name"))

--- a/tests/ahriman/core/build_tools/test_sources.py
+++ b/tests/ahriman/core/build_tools/test_sources.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 from unittest import mock
 
 from ahriman.core.build_tools.sources import Sources
+from ahriman.models.remote_source import RemoteSource
 
 
 def test_add(mocker: MockerFixture) -> None:
@@ -45,7 +46,7 @@ def test_diff(mocker: MockerFixture) -> None:
                                               exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
 
 
-def test_fetch_empty(mocker: MockerFixture) -> None:
+def test_fetch_empty(remote_source: RemoteSource, mocker: MockerFixture) -> None:
     """
     must do nothing in case if no branches available
     """
@@ -53,46 +54,51 @@ def test_fetch_empty(mocker: MockerFixture) -> None:
     mocker.patch("ahriman.core.build_tools.sources.Sources.has_remotes", return_value=False)
     check_output_mock = mocker.patch("ahriman.core.build_tools.sources.Sources._check_output")
 
-    Sources.fetch(Path("local"), "remote")
+    Sources.fetch(Path("local"), remote_source)
     check_output_mock.assert_not_called()
 
 
-def test_fetch_existing(mocker: MockerFixture) -> None:
+def test_fetch_existing(remote_source: RemoteSource, mocker: MockerFixture) -> None:
     """
     must fetch new package via fetch command
     """
     mocker.patch("pathlib.Path.is_dir", return_value=True)
     mocker.patch("ahriman.core.build_tools.sources.Sources.has_remotes", return_value=True)
     check_output_mock = mocker.patch("ahriman.core.build_tools.sources.Sources._check_output")
+    move_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.move")
 
     local = Path("local")
-    Sources.fetch(local, "remote")
+    Sources.fetch(local, remote_source)
     check_output_mock.assert_has_calls([
-        mock.call("git", "fetch", "origin", Sources._branch,
+        mock.call("git", "fetch", "origin", remote_source.branch,
                   exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "checkout", "--force", Sources._branch,
+        mock.call("git", "checkout", "--force", remote_source.branch,
                   exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "reset", "--hard", f"origin/{Sources._branch}",
+        mock.call("git", "reset", "--hard", f"origin/{remote_source.branch}",
                   exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
     ])
+    move_mock.assert_called_once_with(local.resolve(), local)
 
 
-def test_fetch_new(mocker: MockerFixture) -> None:
+def test_fetch_new(remote_source: RemoteSource, mocker: MockerFixture) -> None:
     """
     must fetch new package via clone command
     """
     mocker.patch("pathlib.Path.is_dir", return_value=False)
     check_output_mock = mocker.patch("ahriman.core.build_tools.sources.Sources._check_output")
+    move_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.move")
 
     local = Path("local")
-    Sources.fetch(local, "remote")
+    Sources.fetch(local, remote_source)
     check_output_mock.assert_has_calls([
-        mock.call("git", "clone", "remote", str(local), exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "checkout", "--force", Sources._branch,
+        mock.call("git", "clone", "--branch", remote_source.branch, "--single-branch",
+                  remote_source.git_url, str(local), exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
+        mock.call("git", "checkout", "--force", remote_source.branch,
                   exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "reset", "--hard", f"origin/{Sources._branch}",
+        mock.call("git", "reset", "--hard", f"origin/{remote_source.branch}",
                   exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
     ])
+    move_mock.assert_called_once_with(local.resolve(), local)
 
 
 def test_fetch_new_without_remote(mocker: MockerFixture) -> None:
@@ -101,15 +107,28 @@ def test_fetch_new_without_remote(mocker: MockerFixture) -> None:
     """
     mocker.patch("pathlib.Path.is_dir", return_value=False)
     check_output_mock = mocker.patch("ahriman.core.build_tools.sources.Sources._check_output")
+    move_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.move")
 
     local = Path("local")
     Sources.fetch(local, None)
     check_output_mock.assert_has_calls([
-        mock.call("git", "checkout", "--force", Sources._branch,
+        mock.call("git", "checkout", "--force", Sources.DEFAULT_BRANCH,
                   exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "reset", "--hard", f"origin/{Sources._branch}",
+        mock.call("git", "reset", "--hard", f"origin/{Sources.DEFAULT_BRANCH}",
                   exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
     ])
+    move_mock.assert_called_once_with(local.resolve(), local)
+
+
+def test_fetch_relative(remote_source: RemoteSource, mocker: MockerFixture) -> None:
+    """
+    must process move correctly on relative directory
+    """
+    mocker.patch("ahriman.core.build_tools.sources.Sources._check_output")
+    move_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.move")
+
+    Sources.fetch(Path("path"), remote_source)
+    move_mock.assert_called_once_with(Path("path").resolve(), Path("path"))
 
 
 def test_has_remotes(mocker: MockerFixture) -> None:
@@ -140,31 +159,51 @@ def test_init(mocker: MockerFixture) -> None:
 
     local = Path("local")
     Sources.init(local)
-    check_output_mock.assert_called_once_with("git", "init", "--initial-branch", Sources._branch,
+    check_output_mock.assert_called_once_with("git", "init", "--initial-branch", Sources.DEFAULT_BRANCH,
                                               exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
 
 
-def test_load(mocker: MockerFixture) -> None:
+def test_load(remote_source: RemoteSource, mocker: MockerFixture) -> None:
     """
     must load packages sources correctly
     """
     fetch_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.fetch")
     patch_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.patch_apply")
 
-    Sources.load(Path("local"), "remote", "patch")
-    fetch_mock.assert_called_once_with(Path("local"), "remote")
+    Sources.load(Path("local"), remote_source, "patch")
+    fetch_mock.assert_called_once_with(Path("local"), remote_source)
     patch_mock.assert_called_once_with(Path("local"), "patch")
 
 
-def test_load_no_patch(mocker: MockerFixture) -> None:
+def test_load_no_patch(remote_source: RemoteSource, mocker: MockerFixture) -> None:
     """
     must load packages sources correctly without patches
     """
     mocker.patch("ahriman.core.build_tools.sources.Sources.fetch")
     patch_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.patch_apply")
 
-    Sources.load(Path("local"), "remote", None)
+    Sources.load(Path("local"), remote_source, None)
     patch_mock.assert_not_called()
+
+
+def test_move(mocker: MockerFixture) -> None:
+    """
+    must move content between directories
+    """
+    mocker.patch("ahriman.core.build_tools.sources.walk", return_value=[Path("/source/path")])
+    move_mock = mocker.patch("shutil.move")
+
+    Sources.move(Path("/source"), Path("/destination"))
+    move_mock.assert_called_once_with(Path("/source/path"), Path("/destination/path"))
+
+
+def test_move_same(mocker: MockerFixture) -> None:
+    """
+    must not do anything in case if directories are the same
+    """
+    walk_mock = mocker.patch("ahriman.core.build_tools.sources.walk")
+    Sources.move(Path("/same"), Path("/same"))
+    walk_mock.assert_not_called()
 
 
 def test_patch_apply(mocker: MockerFixture) -> None:

--- a/tests/ahriman/core/conftest.py
+++ b/tests/ahriman/core/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.repo import Repo
 from ahriman.core.build_tools.task import Task
 from ahriman.core.configuration import Configuration
@@ -35,20 +34,6 @@ def leaf_python_schedule(package_python_schedule: Package) -> Leaf:
         Leaf: tree leaf test instance
     """
     return Leaf(package_python_schedule, set())
-
-
-@pytest.fixture
-def pacman(configuration: Configuration) -> Pacman:
-    """
-    fixture for pacman wrapper
-
-    Args:
-        configuration(Configuration): configuration fixture
-
-    Returns:
-        Pacman: pacman wrapper test instance
-    """
-    return Pacman(configuration)
 
 
 @pytest.fixture

--- a/tests/ahriman/core/database/data/test_data_init.py
+++ b/tests/ahriman/core/database/data/test_data_init.py
@@ -15,11 +15,24 @@ def test_migrate_data_initial(connection: Connection, configuration: Configurati
     packages = mocker.patch("ahriman.core.database.data.migrate_package_statuses")
     patches = mocker.patch("ahriman.core.database.data.migrate_patches")
     users = mocker.patch("ahriman.core.database.data.migrate_users_data")
+    remotes = mocker.patch("ahriman.core.database.data.migrate_package_remotes")
 
     migrate_data(MigrationResult(old_version=0, new_version=900), connection, configuration)
     packages.assert_called_once_with(connection, repository_paths)
     patches.assert_called_once_with(connection, repository_paths)
     users.assert_called_once_with(connection, configuration)
+    remotes.assert_called_once_with(connection, repository_paths)
+
+
+def test_migrate_data_remotes(connection: Connection, configuration: Configuration,
+                              repository_paths: RepositoryPaths, mocker: MockerFixture) -> None:
+    """
+    must perform initial migration
+    """
+    remotes = mocker.patch("ahriman.core.database.data.migrate_package_remotes")
+
+    migrate_data(MigrationResult(old_version=1, new_version=900), connection, configuration)
+    remotes.assert_called_once_with(connection, repository_paths)
 
 
 def test_migrate_data_skip(connection: Connection, configuration: Configuration, mocker: MockerFixture) -> None:

--- a/tests/ahriman/core/database/data/test_package_remotes.py
+++ b/tests/ahriman/core/database/data/test_package_remotes.py
@@ -1,0 +1,66 @@
+import pytest
+
+from pytest_mock import MockerFixture
+from sqlite3 import Connection
+
+from ahriman.core.database.data import migrate_package_remotes
+from ahriman.models.package import Package
+from ahriman.models.repository_paths import RepositoryPaths
+
+
+def test_migrate_package_remotes(package_ahriman: Package, connection: Connection, repository_paths: RepositoryPaths,
+                                 mocker: MockerFixture) -> None:
+    """
+    must put package remotes to database
+    """
+    mocker.patch(
+        "ahriman.core.database.operations.package_operations.PackageOperations._packages_get_select_package_bases",
+        return_value={package_ahriman.base: package_ahriman})
+    mocker.patch("pathlib.Path.exists", return_value=False)
+
+    migrate_package_remotes(connection, repository_paths)
+    connection.execute.assert_called_once_with(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int))
+
+
+def test_migrate_package_remotes_has_local(package_ahriman: Package, connection: Connection,
+                                           repository_paths: RepositoryPaths, mocker: MockerFixture) -> None:
+    """
+    must skip processing for packages which have local cache
+    """
+    mocker.patch(
+        "ahriman.core.database.operations.package_operations.PackageOperations._packages_get_select_package_bases",
+        return_value={package_ahriman.base: package_ahriman})
+    mocker.patch("pathlib.Path.exists", return_value=True)
+
+    migrate_package_remotes(connection, repository_paths)
+    connection.execute.assert_not_called()
+
+
+def test_migrate_package_remotes_vcs(package_ahriman: Package, connection: Connection,
+                                     repository_paths: RepositoryPaths, mocker: MockerFixture) -> None:
+    """
+    must process VCS packages with local cache
+    """
+    mocker.patch(
+        "ahriman.core.database.operations.package_operations.PackageOperations._packages_get_select_package_bases",
+        return_value={package_ahriman.base: package_ahriman})
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    mocker.patch.object(Package, "is_vcs", True)
+
+    migrate_package_remotes(connection, repository_paths)
+    connection.execute.assert_called_once_with(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int))
+
+
+def test_migrate_package_remotes_no_remotes(package_ahriman: Package, connection: Connection,
+                                            repository_paths: RepositoryPaths, mocker: MockerFixture) -> None:
+    """
+    must skip processing in case if no remotes generated (should never happen)
+    """
+    mocker.patch(
+        "ahriman.core.database.operations.package_operations.PackageOperations._packages_get_select_package_bases",
+        return_value={package_ahriman.base: package_ahriman})
+    mocker.patch("pathlib.Path.exists", return_value=False)
+    mocker.patch("ahriman.models.remote_source.RemoteSource.from_remote", return_value=None)
+
+    migrate_package_remotes(connection, repository_paths)
+    connection.execute.assert_not_called()

--- a/tests/ahriman/core/database/data/test_users.py
+++ b/tests/ahriman/core/database/data/test_users.py
@@ -9,7 +9,7 @@ from ahriman.core.database.data import migrate_users_data
 
 def test_migrate_users_data(connection: Connection, configuration: Configuration) -> None:
     """
-    must users to database
+    must put users to database
     """
     configuration.set_option("auth:read", "user1", "password1")
     configuration.set_option("auth:write", "user2", "password2")

--- a/tests/ahriman/core/database/migrations/test_m001_package_source.py
+++ b/tests/ahriman/core/database/migrations/test_m001_package_source.py
@@ -1,0 +1,8 @@
+from ahriman.core.database.migrations.m001_package_source import steps
+
+
+def test_migration_package_source() -> None:
+    """
+    migration must not be empty
+    """
+    assert steps

--- a/tests/ahriman/core/database/operations/test_package_operations.py
+++ b/tests/ahriman/core/database/operations/test_package_operations.py
@@ -7,6 +7,8 @@ from unittest import mock
 from ahriman.core.database.sqlite import SQLite
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.package import Package
+from ahriman.models.package_source import PackageSource
+from ahriman.models.remote_source import RemoteSource
 
 
 def test_package_remove_package_base(database: SQLite, connection: Connection) -> None:
@@ -166,3 +168,23 @@ def test_package_update_update(database: SQLite, package_ahriman: Package) -> No
     assert next(db_status.status
                 for db_package, db_status in database.packages_get()
                 if db_package.base == package_ahriman.base) == BuildStatusEnum.Failed
+
+
+def test_remote_update_get(database: SQLite, package_ahriman: Package) -> None:
+    """
+    must insert and retrieve package remote
+    """
+    database.remote_update(package_ahriman)
+    assert database.remotes_get()[package_ahriman.base] == package_ahriman.remote
+
+
+def test_remote_update_update(database: SQLite, package_ahriman: Package) -> None:
+    """
+    must perform package remote update for existing package
+    """
+    database.remote_update(package_ahriman)
+    remote_source = RemoteSource.from_remote(PackageSource.Repository, package_ahriman.base, "community")
+    package_ahriman.remote = remote_source
+
+    database.remote_update(package_ahriman)
+    assert database.remotes_get()[package_ahriman.base] == remote_source

--- a/tests/ahriman/core/repository/test_repository.py
+++ b/tests/ahriman/core/repository/test_repository.py
@@ -15,11 +15,11 @@ def test_load_archives(package_ahriman: Package, package_python_schedule: Packag
     single_packages = [
         Package(base=package_python_schedule.base,
                 version=package_python_schedule.version,
-                aur_url=package_python_schedule.aur_url,
+                remote=package_python_schedule.remote,
                 packages={package: props})
         for package, props in package_python_schedule.packages.items()
     ] + [package_ahriman]
-    mocker.patch("ahriman.models.package.Package.load", side_effect=single_packages)
+    mocker.patch("ahriman.models.package.Package.from_archive", side_effect=single_packages)
 
     packages = repository.load_archives([Path("a.pkg.tar.xz"), Path("b.pkg.tar.xz"), Path("c.pkg.tar.xz")])
     assert len(packages) == 2
@@ -36,7 +36,7 @@ def test_load_archives_failed(repository: Repository, mocker: MockerFixture) -> 
     """
     must skip packages which cannot be loaded
     """
-    mocker.patch("ahriman.models.package.Package.load", side_effect=Exception())
+    mocker.patch("ahriman.models.package.Package.from_archive", side_effect=Exception())
     assert not repository.load_archives([Path("a.pkg.tar.xz")])
 
 
@@ -55,12 +55,12 @@ def test_load_archives_different_version(repository: Repository, package_python_
     single_packages = [
         Package(base=package_python_schedule.base,
                 version=package_python_schedule.version,
-                aur_url=package_python_schedule.aur_url,
+                remote=package_python_schedule.remote,
                 packages={package: props})
         for package, props in package_python_schedule.packages.items()
     ]
     single_packages[0].version = "0.0.1-1"
-    mocker.patch("ahriman.models.package.Package.load", side_effect=single_packages)
+    mocker.patch("ahriman.models.package.Package.from_archive", side_effect=single_packages)
 
     packages = repository.load_archives([Path("a.pkg.tar.xz"), Path("b.pkg.tar.xz")])
     assert len(packages) == 1

--- a/tests/ahriman/core/test_tree.py
+++ b/tests/ahriman/core/test_tree.py
@@ -51,7 +51,7 @@ def test_leaf_load(package_ahriman: Package, database: SQLite, mocker: MockerFix
     assert leaf.dependencies == {"ahriman-dependency"}
     tempdir_mock.assert_called_once_with()
     load_mock.assert_called_once_with(
-        pytest.helpers.anyvar(int), package_ahriman.git_url, database.patches_get(package_ahriman.base))
+        pytest.helpers.anyvar(int), package_ahriman.remote, database.patches_get(package_ahriman.base))
     dependencies_mock.assert_called_once_with(pytest.helpers.anyvar(int))
     rmtree_mock.assert_called_once_with(pytest.helpers.anyvar(int), ignore_errors=True)
 

--- a/tests/ahriman/models/test_aur_package.py
+++ b/tests/ahriman/models/test_aur_package.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import pyalpm  # typing: ignore
 
 from dataclasses import asdict, fields
 from pathlib import Path
@@ -51,6 +52,22 @@ def test_from_json_2(aur_package_ahriman: AURPackage, mocker: MockerFixture) -> 
     """
     mocker.patch("ahriman.models.aur_package.AURPackage.convert", side_effect=lambda v: v)
     assert AURPackage.from_json(asdict(aur_package_ahriman)) == aur_package_ahriman
+
+
+def test_from_pacman(pyalpm_package_ahriman: pyalpm.Package, aur_package_ahriman: AURPackage,
+                     resource_path_root: Path) -> None:
+    """
+    must load package from repository database
+    """
+    model = AURPackage.from_pacman(pyalpm_package_ahriman)
+    # some fields are missing so we are changing them
+    model.id = aur_package_ahriman.id
+    model.package_base_id = aur_package_ahriman.package_base_id
+    model.first_submitted = aur_package_ahriman.first_submitted
+    model.url_path = aur_package_ahriman.url_path
+    model.maintainer = aur_package_ahriman.maintainer
+
+    assert model == aur_package_ahriman
 
 
 def test_from_repo(aur_package_akonadi: AURPackage, resource_path_root: Path) -> None:

--- a/tests/ahriman/models/test_package_description.py
+++ b/tests/ahriman/models/test_package_description.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 from unittest.mock import MagicMock
 
 from ahriman.models.package_description import PackageDescription
@@ -24,14 +23,14 @@ def test_from_json(package_description_ahriman: PackageDescription) -> None:
     """
     must construct description from json object
     """
-    assert PackageDescription.from_json(asdict(package_description_ahriman)) == package_description_ahriman
+    assert PackageDescription.from_json(package_description_ahriman.view()) == package_description_ahriman
 
 
 def test_from_json_with_unknown_fields(package_description_ahriman: PackageDescription) -> None:
     """
     must construct description from json object containing unknown fields
     """
-    dump = asdict(package_description_ahriman)
+    dump = package_description_ahriman.view()
     dump.update(unknown_field="value")
     assert PackageDescription.from_json(dump) == package_description_ahriman
 

--- a/tests/ahriman/models/test_remote_source.py
+++ b/tests/ahriman/models/test_remote_source.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from pytest_mock import MockerFixture
+
+from ahriman.models.package import Package
+from ahriman.models.package_source import PackageSource
+from ahriman.models.remote_source import RemoteSource
+
+
+def test_post_init(remote_source: RemoteSource) -> None:
+    """
+    must convert string source to enum
+    """
+    remote = RemoteSource(
+        git_url=remote_source.git_url,
+        web_url=remote_source.web_url,
+        path=remote_source.path,
+        branch=remote_source.branch,
+        source=remote_source.source.value,
+    )
+    assert remote == remote_source
+
+
+def test_pkgbuild_dir(remote_source: RemoteSource) -> None:
+    """
+    must return path as is in `path` property
+    """
+    assert isinstance(remote_source.pkgbuild_dir, Path)
+    assert remote_source.pkgbuild_dir.name == ""
+
+
+def test_from_json(remote_source: RemoteSource) -> None:
+    """
+    must construct remote source from json
+    """
+    assert RemoteSource.from_json(remote_source.view()) == remote_source
+
+
+def test_from_json_empty() -> None:
+    """
+    must return None in case of empty dictionary, which is required by the database wrapper
+    """
+    assert RemoteSource.from_json({}) is None
+
+
+def test_from_remote_aur(package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must construct remote from AUR source
+    """
+    remote_git_url_mock = mocker.patch("ahriman.core.alpm.remote.aur.AUR.remote_git_url")
+    remote_web_url_mock = mocker.patch("ahriman.core.alpm.remote.aur.AUR.remote_web_url")
+
+    remote = RemoteSource.from_remote(PackageSource.AUR, package_ahriman.base, "aur")
+    remote_git_url_mock.assert_called_once_with(package_ahriman.base, "aur")
+    remote_web_url_mock.assert_called_once_with(package_ahriman.base)
+    assert remote.pkgbuild_dir == Path(".")
+    assert remote.branch == "master"
+    assert remote.source == PackageSource.AUR
+
+
+def test_from_remote_official(package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must construct remote from official repository source
+    """
+    remote_git_url_mock = mocker.patch("ahriman.core.alpm.remote.official.Official.remote_git_url")
+    remote_web_url_mock = mocker.patch("ahriman.core.alpm.remote.official.Official.remote_web_url")
+
+    remote = RemoteSource.from_remote(PackageSource.Repository, package_ahriman.base, "community")
+    remote_git_url_mock.assert_called_once_with(package_ahriman.base, "community")
+    remote_web_url_mock.assert_called_once_with(package_ahriman.base)
+    assert remote.pkgbuild_dir == Path("trunk")
+    assert remote.branch.endswith(package_ahriman.base)
+    assert remote.source == PackageSource.Repository
+
+
+def test_from_remote_other() -> None:
+    """
+    must return None in case if source is not one of AUR or Repository
+    """
+    assert RemoteSource.from_remote(PackageSource.Archive, "package", "repository") is None
+    assert RemoteSource.from_remote(PackageSource.Directory, "package", "repository") is None
+    assert RemoteSource.from_remote(PackageSource.Local, "package", "repository") is None
+    assert RemoteSource.from_remote(PackageSource.Remote, "package", "repository") is None

--- a/tests/ahriman/web/views/service/test_views_service_search.py
+++ b/tests/ahriman/web/views/service/test_views_service_search.py
@@ -37,7 +37,7 @@ async def test_get_exception(client: TestClient, mocker: MockerFixture) -> None:
     response = await client.get("/service-api/v1/search")
 
     assert response.status == 404
-    search_mock.assert_called_once_with()
+    search_mock.assert_called_once_with(pacman=pytest.helpers.anyvar(int))
 
 
 async def test_get_join(client: TestClient, mocker: MockerFixture) -> None:
@@ -48,4 +48,4 @@ async def test_get_join(client: TestClient, mocker: MockerFixture) -> None:
     response = await client.get("/service-api/v1/search", params=[("for", "ahriman"), ("for", "maybe")])
 
     assert response.ok
-    search_mock.assert_called_once_with("ahriman", "maybe")
+    search_mock.assert_called_once_with("ahriman", "maybe", pacman=pytest.helpers.anyvar(int))

--- a/tests/testresources/core/ahriman.ini
+++ b/tests/testresources/core/ahriman.ini
@@ -4,7 +4,6 @@ logging = logging.ini
 database = ../../../ahriman-test.db
 
 [alpm]
-aur_url = https://aur.archlinux.org
 database = /var/lib/pacman
 repositories = core extra community multilib
 root = /


### PR DESCRIPTION
## Summary

Previously some code has been added for official repositories support https://github.com/arcan1s/ahriman/commit/e200ac97762f86ee16d8689990429622fb498350. However it is still incomplete, packages can be searched, but cannot be retrieved, no official repository update support.

Originally I wanted to move some data about packages to database with initial migrations, it looks like I still have to do it, but in a bit different way.

Since official packages provide a bit different git interface, e.g. https://github.com/archlinux/svntogit-packages/blob/packages/akonadi/trunk/PKGBUILD (note that root is different and branch is different also), also it splits packages by core/extra and community repositories, the original git_url property has to be extended to dataclass descriptor

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
