### PR TITLE
Single-function patches

### DIFF
--- a/docs/ahriman.1
+++ b/docs/ahriman.1
@@ -3,7 +3,7 @@
 ahriman
 .SH SYNOPSIS
 .B ahriman
-[-h] [-a ARCHITECTURE] [-c CONFIGURATION] [--force] [-l LOCK] [--no-report] [-q] [--unsafe] [-V] {aur-search,search,help,help-commands-unsafe,key-import,package-add,add,package-update,package-remove,remove,package-status,status,package-status-remove,package-status-update,status-update,patch-add,patch-list,patch-remove,repo-backup,repo-check,check,repo-clean,clean,repo-config,config,repo-rebuild,rebuild,repo-remove-unknown,remove-unknown,repo-report,report,repo-restore,repo-setup,init,repo-init,setup,repo-sign,sign,repo-status-update,repo-sync,sync,repo-triggers,repo-update,update,shell,user-add,user-list,user-remove,version,web} ...
+[-h] [-a ARCHITECTURE] [-c CONFIGURATION] [--force] [-l LOCK] [--no-report] [-q] [--unsafe] [-V] {aur-search,search,help,help-commands-unsafe,key-import,package-add,add,package-update,package-remove,remove,package-status,status,package-status-remove,package-status-update,status-update,patch-add,patch-list,patch-remove,patch-set-add,repo-backup,repo-check,check,repo-clean,clean,repo-config,config,repo-rebuild,rebuild,repo-remove-unknown,remove-unknown,repo-report,report,repo-restore,repo-setup,init,repo-init,setup,repo-sign,sign,repo-status-update,repo-sync,sync,repo-triggers,repo-update,update,shell,user-add,user-list,user-remove,version,web} ...
 .SH DESCRIPTION
 ArcH linux ReposItory MANager
 
@@ -71,13 +71,16 @@ remove package status
 update package status
 .TP
 \fBahriman\fR \fI\,patch-add\/\fR
-add patch set
+add patch for PKGBUILD function
 .TP
 \fBahriman\fR \fI\,patch-list\/\fR
 list patch sets
 .TP
 \fBahriman\fR \fI\,patch-remove\/\fR
 remove patch set
+.TP
+\fBahriman\fR \fI\,patch-set-add\/\fR
+add patch set
 .TP
 \fBahriman\fR \fI\,repo-backup\/\fR
 backup repository data
@@ -284,21 +287,25 @@ set status for specified packages. If no packages supplied, service status will 
 new status
 
 .SH COMMAND \fI\,'ahriman patch-add'\/\fR
-usage: ahriman patch-add [-h] [-t TRACK] package
+usage: ahriman patch-add [-h] [-p PATCH] package variable
 
-create or update source patches
+create or update patched PKGBUILD function or variable
 
 .TP
 \fBpackage\fR
-path to directory with changed files for patch addition/update
+package base
+
+.TP
+\fBvariable\fR
+PKGBUILD variable or function name. If variable is a function, it must end with ()
 
 .SH OPTIONS \fI\,'ahriman patch-add'\/\fR
 .TP
-\fB\-t\fR \fI\,TRACK\/\fR, \fB\-\-track\fR \fI\,TRACK\/\fR
-files which has to be tracked
+\fB\-p\fR \fI\,PATCH\/\fR, \fB\-\-patch\fR \fI\,PATCH\/\fR
+path to file which contains function or variable value. If not set, the value will be read from stdin
 
 .SH COMMAND \fI\,'ahriman patch-list'\/\fR
-usage: ahriman patch-list [-h] [-e] [package]
+usage: ahriman patch-list [-h] [-e] [-v VARIABLE] [package]
 
 list available patches for the package
 
@@ -311,14 +318,38 @@ package base
 \fB\-e\fR, \fB\-\-exit\-code\fR
 return non\-zero exit status if result is empty
 
+.TP
+\fB\-v\fR \fI\,VARIABLE\/\fR, \fB\-\-variable\fR \fI\,VARIABLE\/\fR
+if set, show only patches for specified PKGBUILD variables
+
 .SH COMMAND \fI\,'ahriman patch-remove'\/\fR
-usage: ahriman patch-remove [-h] package
+usage: ahriman patch-remove [-h] [-v VARIABLE] package
 
 remove patches for the package
 
 .TP
 \fBpackage\fR
 package base
+
+.SH OPTIONS \fI\,'ahriman patch-remove'\/\fR
+.TP
+\fB\-v\fR \fI\,VARIABLE\/\fR, \fB\-\-variable\fR \fI\,VARIABLE\/\fR
+should be used for single\-function patches in case if you wold like to remove only specified PKGBUILD variables. In case
+if not set, it will remove all patches related to the package
+
+.SH COMMAND \fI\,'ahriman patch-set-add'\/\fR
+usage: ahriman patch-set-add [-h] [-t TRACK] package
+
+create or update source patches
+
+.TP
+\fBpackage\fR
+path to directory with changed files for patch addition/update
+
+.SH OPTIONS \fI\,'ahriman patch-set-add'\/\fR
+.TP
+\fB\-t\fR \fI\,TRACK\/\fR, \fB\-\-track\fR \fI\,TRACK\/\fR
+files which has to be tracked
 
 .SH COMMAND \fI\,'ahriman repo-backup'\/\fR
 usage: ahriman repo-backup [-h] path

--- a/docs/ahriman.core.database.migrations.rst
+++ b/docs/ahriman.core.database.migrations.rst
@@ -28,6 +28,14 @@ ahriman.core.database.migrations.m002\_user\_access module
    :no-undoc-members:
    :show-inheritance:
 
+ahriman.core.database.migrations.m003\_patch\_variables module
+--------------------------------------------------------------
+
+.. automodule:: ahriman.core.database.migrations.m003_patch_variables
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/ahriman.core.formatters.rst
+++ b/docs/ahriman.core.formatters.rst
@@ -36,6 +36,14 @@ ahriman.core.formatters.package\_printer module
    :no-undoc-members:
    :show-inheritance:
 
+ahriman.core.formatters.patch\_printer module
+---------------------------------------------
+
+.. automodule:: ahriman.core.formatters.patch_printer
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
 ahriman.core.formatters.printer module
 --------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -162,11 +162,13 @@ Unlike ``RemotePullTrigger`` trigger, the ``RemotePushTrigger`` more likely will
 But I just wanted to change PKGBUILD from AUR a bit!
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Well it is supported also.
+Well it is supported also. The recommended way is to patch specific function, e.g. by running ``sudo -u ahriman ahriman patch-add ahriman version``. This command will prompt for new value of the PKGBUILD variable ``version``. You can also write it to file and read from it ``sudo -u ahriman ahriman patch-add ahriman version version.patch``.
+
+Alternatively you can create full-diff patches, which are calculated by using ``git diff`` from current PKGBUILD master branch:
 
 #. Clone sources from AUR.
 #. Make changes you would like to (e.g. edit ``PKGBUILD``, add external patches).
-#. Run ``sudo -u ahriman ahriman patch-add /path/to/local/directory/with/PKGBUILD``.
+#. Run ``sudo -u ahriman ahriman patch-set-add /path/to/local/directory/with/PKGBUILD``.
 
 The last command will calculate diff from current tree to the ``HEAD`` and will store it locally. Patches will be applied on any package actions (e.g. it can be used for dependency management).
 

--- a/src/ahriman/core/database/migrations/m003_patch_variables.py
+++ b/src/ahriman/core/database/migrations/m003_patch_variables.py
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2021-2022 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+__all__ = ["steps"]
+
+
+steps = [
+    """
+    alter table patches rename to patches_
+    """,
+    """
+    create table patches (
+        package_base text not null,
+        variable text,
+        patch blob not null
+    )
+    """,
+    """
+    create unique index patches_package_base_variable on patches (package_base, coalesce(variable, ''))
+    """,
+    """
+    insert into patches (package_base, patch) select package_base, patch from patches_
+    """,
+    """
+    drop table patches_
+    """,
+]

--- a/src/ahriman/core/formatters/__init__.py
+++ b/src/ahriman/core/formatters/__init__.py
@@ -24,6 +24,7 @@ from ahriman.core.formatters.aur_printer import AurPrinter
 from ahriman.core.formatters.build_printer import BuildPrinter
 from ahriman.core.formatters.configuration_printer import ConfigurationPrinter
 from ahriman.core.formatters.package_printer import PackagePrinter
+from ahriman.core.formatters.patch_printer import PatchPrinter
 from ahriman.core.formatters.status_printer import StatusPrinter
 from ahriman.core.formatters.update_printer import UpdatePrinter
 from ahriman.core.formatters.user_printer import UserPrinter

--- a/src/ahriman/core/formatters/patch_printer.py
+++ b/src/ahriman/core/formatters/patch_printer.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2021-2022 ahriman team.
+#
+# This file is part of ahriman
+# (see https://github.com/arcan1s/ahriman).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from typing import List
+
+from ahriman.core.formatters import StringPrinter
+from ahriman.models.pkgbuild_patch import PkgbuildPatch
+from ahriman.models.property import Property
+
+
+class PatchPrinter(StringPrinter):
+    """
+    print content of the PKGBUILD patch
+
+    Attributes:
+        patches(List[PkgbuildPatch]): PKGBUILD patch object
+    """
+
+    def __init__(self, package_base: str, patches: List[PkgbuildPatch]) -> None:
+        """
+        default constructor
+
+        Args:
+            package_base(str): package base
+            patches(List[PkgbuildPatch]): PKGBUILD patch object
+        """
+        StringPrinter.__init__(self, package_base)
+        self.patches = patches
+
+    def properties(self) -> List[Property]:
+        """
+        convert content into printable data
+
+        Returns:
+            List[Property]: list of content properties
+        """
+        return [
+            Property(patch.key or "Full source diff", patch.value, is_required=True)
+            for patch in self.patches
+        ]

--- a/src/ahriman/core/repository/executor.py
+++ b/src/ahriman/core/repository/executor.py
@@ -109,7 +109,7 @@ class Executor(Cleaner):
             try:
                 self.paths.tree_clear(package_base)  # remove all internal files
                 self.database.build_queue_clear(package_base)
-                self.database.patches_remove(package_base)
+                self.database.patches_remove(package_base, [])
                 self.reporter.remove(package_base)  # we only update status page in case of base removal
             except Exception:
                 self.logger.exception("could not remove base %s", package_base)

--- a/src/ahriman/models/package.py
+++ b/src/ahriman/models/package.py
@@ -305,7 +305,7 @@ class Package(LazyLogging):
 
         from ahriman.core.build_tools.sources import Sources
 
-        Sources.load(paths.cache_for(self.base), self, None, paths)
+        Sources.load(paths.cache_for(self.base), self, [], paths)
 
         try:
             # update pkgver first

--- a/tests/ahriman/application/handlers/test_handler_patch.py
+++ b/tests/ahriman/application/handlers/test_handler_patch.py
@@ -1,5 +1,6 @@
 import argparse
 import pytest
+import sys
 
 from pathlib import Path
 from pytest_mock import MockerFixture
@@ -9,6 +10,7 @@ from ahriman.application.handlers import Patch
 from ahriman.core.configuration import Configuration
 from ahriman.models.action import Action
 from ahriman.models.package import Package
+from ahriman.models.pkgbuild_patch import PkgbuildPatch
 
 
 def _default_args(args: argparse.Namespace) -> argparse.Namespace:
@@ -25,6 +27,7 @@ def _default_args(args: argparse.Namespace) -> argparse.Namespace:
     args.exit_code = False
     args.remove = False
     args.track = ["*.diff", "*.patch"]
+    args.variable = None
     return args
 
 
@@ -35,12 +38,31 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     args = _default_args(args)
     args.action = Action.Update
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
+    patch_mock = mocker.patch("ahriman.application.handlers.Patch.patch_create_from_diff",
+                              return_value=(args.package, PkgbuildPatch(None, "patch")))
     application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_create")
-    on_start_mock = mocker.patch("ahriman.application.application.Application.on_start")
 
     Patch.run(args, "x86_64", configuration, True, False)
-    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), Path(args.package), args.track)
-    on_start_mock.assert_called_once_with()
+    patch_mock.assert_called_once_with(args.package, args.track)
+    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, PkgbuildPatch(None, "patch"))
+
+
+def test_run_function(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
+    """
+    must run command with patch function flag
+    """
+    args = _default_args(args)
+    args.action = Action.Update
+    args.patch = "patch"
+    args.variable = "version"
+    patch = PkgbuildPatch(args.variable, args.patch)
+    mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
+    patch_mock = mocker.patch("ahriman.application.handlers.Patch.patch_create_from_function", return_value=patch)
+    application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_create")
+
+    Patch.run(args, "x86_64", configuration, True, False)
+    patch_mock.assert_called_once_with(args.variable, args.patch)
+    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, patch)
 
 
 def test_run_list(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
@@ -49,11 +71,12 @@ def test_run_list(args: argparse.Namespace, configuration: Configuration, mocker
     """
     args = _default_args(args)
     args.action = Action.List
+    args.variable = ["version"]
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_list")
 
     Patch.run(args, "x86_64", configuration, True, False)
-    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, False)
+    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, ["version"], False)
 
 
 def test_run_remove(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
@@ -62,24 +85,71 @@ def test_run_remove(args: argparse.Namespace, configuration: Configuration, mock
     """
     args = _default_args(args)
     args.action = Action.Remove
+    args.variable = ["version"]
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_remove")
 
     Patch.run(args, "x86_64", configuration, True, False)
-    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package)
+    application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, ["version"])
+
+
+def test_patch_create_from_diff(package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must create patch from directory tree diff
+    """
+    patch = PkgbuildPatch(None, "patch")
+    path = Path("local")
+    mocker.patch("pathlib.Path.mkdir")
+    package_mock = mocker.patch("ahriman.models.package.Package.from_build", return_value=package_ahriman)
+    sources_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.patch_create", return_value=patch.value)
+
+    assert Patch.patch_create_from_diff(path, ["*.diff"]) == (package_ahriman.base, patch)
+    package_mock.assert_called_once_with(path)
+    sources_mock.assert_called_once_with(path, "*.diff")
+
+
+def test_patch_create_from_function(mocker: MockerFixture) -> None:
+    """
+    must create function patch from file
+    """
+    path = Path("local")
+    patch = PkgbuildPatch("version", "patch")
+    read_mock = mocker.patch("pathlib.Path.read_text", return_value=patch.value)
+
+    assert Patch.patch_create_from_function(patch.key, path) == patch
+    read_mock.assert_called_once_with(encoding="utf8")
+
+
+def test_patch_create_from_function_stdin(mocker: MockerFixture) -> None:
+    """
+    must create function patch from stdin
+    """
+    patch = PkgbuildPatch("version", "This is a patch")
+    mocker.patch.object(sys, "stdin", patch.value.splitlines())
+    assert Patch.patch_create_from_function(patch.key, None) == patch
+
+
+def test_patch_create_from_function_strip(mocker: MockerFixture) -> None:
+    """
+    must remove spaces at the beginning and at the end of the line
+    """
+    patch = PkgbuildPatch("version", "This is a patch")
+    mocker.patch.object(sys, "stdin", ["\n"] + patch.value.splitlines() + ["\n"])
+    assert Patch.patch_create_from_function(patch.key, None) == patch
 
 
 def test_patch_set_list(application: Application, mocker: MockerFixture) -> None:
     """
     must list available patches for the command
     """
-    get_mock = mocker.patch("ahriman.core.database.SQLite.patches_list", return_value={"ahriman": "patch"})
+    get_mock = mocker.patch("ahriman.core.database.SQLite.patches_list",
+                            return_value={"ahriman": PkgbuildPatch(None, "patch")})
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Patch.patch_set_list(application, "ahriman", False)
-    get_mock.assert_called_once_with("ahriman")
-    print_mock.assert_called_once_with(verbose=True)
+    Patch.patch_set_list(application, "ahriman", ["version"], False)
+    get_mock.assert_called_once_with("ahriman", ["version"])
+    print_mock.assert_called_once_with(verbose=True, separator=" = ")
     check_mock.assert_called_once_with(False, False)
 
 
@@ -90,7 +160,7 @@ def test_patch_set_list_empty_exception(application: Application, mocker: Mocker
     mocker.patch("ahriman.core.database.SQLite.patches_list", return_value={})
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Patch.patch_set_list(application, "ahriman", True)
+    Patch.patch_set_list(application, "ahriman", [], True)
     check_mock.assert_called_once_with(True, True)
 
 
@@ -98,13 +168,9 @@ def test_patch_set_create(application: Application, package_ahriman: Package, mo
     """
     must create patch set for the package
     """
-    mocker.patch("pathlib.Path.mkdir")
-    mocker.patch("ahriman.models.package.Package.from_build", return_value=package_ahriman)
-    mocker.patch("ahriman.core.build_tools.sources.Sources.patch_create", return_value="patch")
     create_mock = mocker.patch("ahriman.core.database.SQLite.patches_insert")
-
-    Patch.patch_set_create(application, Path("path"), ["*.patch"])
-    create_mock.assert_called_once_with(package_ahriman.base, "patch")
+    Patch.patch_set_create(application, package_ahriman.base, PkgbuildPatch("version", package_ahriman.version))
+    create_mock.assert_called_once_with(package_ahriman.base, PkgbuildPatch("version", package_ahriman.version))
 
 
 def test_patch_set_remove(application: Application, package_ahriman: Package, mocker: MockerFixture) -> None:
@@ -112,5 +178,5 @@ def test_patch_set_remove(application: Application, package_ahriman: Package, mo
     must remove patch set for the package
     """
     remove_mock = mocker.patch("ahriman.core.database.SQLite.patches_remove")
-    Patch.patch_set_remove(application, package_ahriman.base)
-    remove_mock.assert_called_once_with(package_ahriman.base)
+    Patch.patch_set_remove(application, package_ahriman.base, ["version"])
+    remove_mock.assert_called_once_with(package_ahriman.base, ["version"])

--- a/tests/ahriman/application/test_ahriman.py
+++ b/tests/ahriman/application/test_ahriman.py
@@ -197,7 +197,7 @@ def test_subparsers_patch_add(parser: argparse.ArgumentParser) -> None:
     """
     patch-add command must imply action, architecture list, lock and no-report
     """
-    args = parser.parse_args(["patch-add", "ahriman"])
+    args = parser.parse_args(["patch-add", "ahriman", "version"])
     assert args.action == Action.Update
     assert args.architecture == [""]
     assert args.lock is None
@@ -208,16 +208,8 @@ def test_subparsers_patch_add_architecture(parser: argparse.ArgumentParser) -> N
     """
     patch-add command must correctly parse architecture list
     """
-    args = parser.parse_args(["-a", "x86_64", "patch-add", "ahriman"])
+    args = parser.parse_args(["-a", "x86_64", "patch-add", "ahriman", "version"])
     assert args.architecture == [""]
-
-
-def test_subparsers_patch_add_track(parser: argparse.ArgumentParser) -> None:
-    """
-    patch-add command must correctly parse track files patterns
-    """
-    args = parser.parse_args(["patch-add", "-t", "*.py", "ahriman"])
-    assert args.track == ["*.diff", "*.patch", "*.py"]
 
 
 def test_subparsers_patch_list(parser: argparse.ArgumentParser) -> None:
@@ -256,6 +248,42 @@ def test_subparsers_patch_remove_architecture(parser: argparse.ArgumentParser) -
     """
     args = parser.parse_args(["-a", "x86_64", "patch-remove", "ahriman"])
     assert args.architecture == [""]
+
+
+def test_subparsers_patch_set_add(parser: argparse.ArgumentParser) -> None:
+    """
+    patch-set-add command must imply action, architecture list, lock, no-report and variable
+    """
+    args = parser.parse_args(["patch-set-add", "ahriman"])
+    assert args.action == Action.Update
+    assert args.architecture == [""]
+    assert args.lock is None
+    assert args.no_report
+    assert args.variable is None
+
+
+def test_subparsers_patch_set_add_architecture(parser: argparse.ArgumentParser) -> None:
+    """
+    patch-set-add command must correctly parse architecture list
+    """
+    args = parser.parse_args(["-a", "x86_64", "patch-set-add", "ahriman"])
+    assert args.architecture == [""]
+
+
+def test_subparsers_patch_set_add_option_package(parser: argparse.ArgumentParser) -> None:
+    """
+    patch-set-add command must convert package option to path instance
+    """
+    args = parser.parse_args(["patch-set-add", "ahriman"])
+    assert isinstance(args.package, Path)
+
+
+def test_subparsers_patch_set_add_option_track(parser: argparse.ArgumentParser) -> None:
+    """
+    patch-set-add command must correctly parse track files patterns
+    """
+    args = parser.parse_args(["patch-set-add", "-t", "*.py", "ahriman"])
+    assert args.track == ["*.diff", "*.patch", "*.py"]
 
 
 def test_subparsers_repo_backup(parser: argparse.ArgumentParser) -> None:

--- a/tests/ahriman/core/build_tools/test_task.py
+++ b/tests/ahriman/core/build_tools/test_task.py
@@ -20,4 +20,4 @@ def test_init(task_ahriman: Task, database: SQLite, mocker: MockerFixture) -> No
     """
     load_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.load")
     task_ahriman.init(Path("ahriman"), database)
-    load_mock.assert_called_once_with(Path("ahriman"), task_ahriman.package, None, task_ahriman.paths)
+    load_mock.assert_called_once_with(Path("ahriman"), task_ahriman.package, [], task_ahriman.paths)

--- a/tests/ahriman/core/database/migrations/test_m003_patch_variables.py
+++ b/tests/ahriman/core/database/migrations/test_m003_patch_variables.py
@@ -1,0 +1,8 @@
+from ahriman.core.database.migrations.m003_patch_variables import steps
+
+
+def test_migration_package_source() -> None:
+    """
+    migration must not be empty
+    """
+    assert steps

--- a/tests/ahriman/core/database/operations/test_patch_operations.py
+++ b/tests/ahriman/core/database/operations/test_patch_operations.py
@@ -1,55 +1,96 @@
 from ahriman.core.database import SQLite
 from ahriman.models.package import Package
+from ahriman.models.pkgbuild_patch import PkgbuildPatch
 
 
 def test_patches_get_insert(database: SQLite, package_ahriman: Package, package_python_schedule: Package) -> None:
     """
     must insert patch to database
     """
-    database.patches_insert(package_ahriman.base, "patch_1")
-    database.patches_insert(package_python_schedule.base, "patch_2")
-    assert database.patches_get(package_ahriman.base) == "patch_1"
-    assert not database.build_queue_get()
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch_1"))
+    database.patches_insert(package_ahriman.base, PkgbuildPatch("key", "patch_3"))
+    database.patches_insert(package_python_schedule.base, PkgbuildPatch(None, "patch_2"))
+    assert database.patches_get(package_ahriman.base) == [
+        PkgbuildPatch(None, "patch_1"), PkgbuildPatch("key", "patch_3")
+    ]
 
 
 def test_patches_list(database: SQLite, package_ahriman: Package, package_python_schedule: Package) -> None:
     """
     must list all patches
     """
-    database.patches_insert(package_ahriman.base, "patch1")
-    database.patches_insert(package_python_schedule.base, "patch2")
-    assert database.patches_list(None) == {package_ahriman.base: "patch1", package_python_schedule.base: "patch2"}
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch1"))
+    database.patches_insert(package_ahriman.base, PkgbuildPatch("key", "patch3"))
+    database.patches_insert(package_python_schedule.base, PkgbuildPatch(None, "patch2"))
+    assert database.patches_list(None, []) == {
+        package_ahriman.base: [PkgbuildPatch(None, "patch1"), PkgbuildPatch("key", "patch3")],
+        package_python_schedule.base: [PkgbuildPatch(None, "patch2")],
+    }
 
 
 def test_patches_list_filter(database: SQLite, package_ahriman: Package, package_python_schedule: Package) -> None:
     """
     must list all patches filtered by package name (same as get)
     """
-    database.patches_insert(package_ahriman.base, "patch1")
-    database.patches_insert(package_python_schedule.base, "patch2")
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch1"))
+    database.patches_insert(package_python_schedule.base, PkgbuildPatch(None, "patch2"))
 
-    assert database.patches_list(package_ahriman.base) == {package_ahriman.base: "patch1"}
-    assert database.patches_list(package_python_schedule.base) == {package_python_schedule.base: "patch2"}
+    assert database.patches_list(package_ahriman.base, []) == {package_ahriman.base: [PkgbuildPatch(None, "patch1")]}
+    assert database.patches_list(package_python_schedule.base, []) == {
+        package_python_schedule.base: [PkgbuildPatch(None, "patch2")],
+    }
+
+
+def test_patches_list_filter_by_variable(database: SQLite, package_ahriman: Package,
+                                         package_python_schedule: Package) -> None:
+    """
+    must list all patches filtered by package name (same as get)
+    """
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch1"))
+    database.patches_insert(package_ahriman.base, PkgbuildPatch("key", "patch2"))
+    database.patches_insert(package_python_schedule.base, PkgbuildPatch(None, "patch3"))
+
+    assert database.patches_list(None, []) == {
+        package_ahriman.base: [PkgbuildPatch(None, "patch1"), PkgbuildPatch("key", "patch2")],
+        package_python_schedule.base: [PkgbuildPatch(None, "patch3")],
+    }
+    assert database.patches_list(None, ["key"]) == {
+        package_ahriman.base: [PkgbuildPatch("key", "patch2")],
+    }
 
 
 def test_patches_insert_remove(database: SQLite, package_ahriman: Package, package_python_schedule: Package) -> None:
     """
     must remove patch from database
     """
-    database.patches_insert(package_ahriman.base, "patch_1")
-    database.patches_insert(package_python_schedule.base, "patch_2")
-    database.patches_remove(package_ahriman.base)
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch1"))
+    database.patches_insert(package_python_schedule.base, PkgbuildPatch(None, "patch2"))
+    database.patches_remove(package_ahriman.base, [])
 
-    assert database.patches_get(package_ahriman.base) is None
-    database.patches_insert(package_python_schedule.base, "patch_2")
+    assert database.patches_get(package_ahriman.base) == []
+    assert database.patches_get(package_python_schedule.base) == [PkgbuildPatch(None, "patch2")]
+
+
+def test_patches_insert_remove_by_variable(database: SQLite, package_ahriman: Package,
+                                           package_python_schedule: Package) -> None:
+    """
+    must remove patch from database by variable
+    """
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch1"))
+    database.patches_insert(package_ahriman.base, PkgbuildPatch("key", "patch3"))
+    database.patches_insert(package_python_schedule.base, PkgbuildPatch(None, "patch2"))
+    database.patches_remove(package_ahriman.base, ["key"])
+
+    assert database.patches_get(package_ahriman.base) == [PkgbuildPatch(None, "patch1")]
+    assert database.patches_get(package_python_schedule.base) == [PkgbuildPatch(None, "patch2")]
 
 
 def test_patches_insert_insert(database: SQLite, package_ahriman: Package) -> None:
     """
     must update patch in database
     """
-    database.patches_insert(package_ahriman.base, "patch_1")
-    assert database.patches_get(package_ahriman.base) == "patch_1"
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch1"))
+    assert database.patches_get(package_ahriman.base) == [PkgbuildPatch(None, "patch1")]
 
-    database.patches_insert(package_ahriman.base, "patch_2")
-    assert database.patches_get(package_ahriman.base) == "patch_2"
+    database.patches_insert(package_ahriman.base, PkgbuildPatch(None, "patch2"))
+    assert database.patches_get(package_ahriman.base) == [PkgbuildPatch(None, "patch2")]

--- a/tests/ahriman/core/formatters/conftest.py
+++ b/tests/ahriman/core/formatters/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 
-from ahriman.core.formatters import AurPrinter, ConfigurationPrinter, PackagePrinter, StatusPrinter, StringPrinter, \
-    UpdatePrinter, UserPrinter, VersionPrinter
+from ahriman.core.formatters import AurPrinter, ConfigurationPrinter, PackagePrinter, PatchPrinter, StatusPrinter, \
+    StringPrinter, UpdatePrinter, UserPrinter, VersionPrinter
 from ahriman.models.aur_package import AURPackage
 from ahriman.models.build_status import BuildStatus
 from ahriman.models.package import Package
+from ahriman.models.pkgbuild_patch import PkgbuildPatch
 from ahriman.models.user import User
 
 
@@ -45,6 +46,20 @@ def package_ahriman_printer(package_ahriman: Package) -> PackagePrinter:
         PackagePrinter: package printer test instance
     """
     return PackagePrinter(package_ahriman, BuildStatus())
+
+
+@pytest.fixture
+def patch_printer(package_ahriman: Package) -> PatchPrinter:
+    """
+    fixture for patch printer
+
+    Args:
+        package_ahriman(Package): package fixture
+
+    Returns:
+        PatchPrinter: patch printer test instance
+    """
+    return PatchPrinter(package_ahriman.base, [PkgbuildPatch("key", "value")])
 
 
 @pytest.fixture

--- a/tests/ahriman/core/formatters/test_patch_printer.py
+++ b/tests/ahriman/core/formatters/test_patch_printer.py
@@ -1,0 +1,22 @@
+from ahriman.core.formatters import PatchPrinter
+
+
+def test_properties(patch_printer: PatchPrinter) -> None:
+    """
+    must return non empty properties list
+    """
+    assert patch_printer.properties()
+
+
+def test_properties_required(patch_printer: PatchPrinter) -> None:
+    """
+    must return all properties as required
+    """
+    assert all(prop.is_required for prop in patch_printer.properties())
+
+
+def test_title(patch_printer: PatchPrinter) -> None:
+    """
+    must return non empty title
+    """
+    assert patch_printer.title() == "ahriman"

--- a/tests/ahriman/core/repository/test_executor.py
+++ b/tests/ahriman/core/repository/test_executor.py
@@ -72,7 +72,7 @@ def test_process_remove_base(executor: Executor, package_ahriman: Package, mocke
     # must update status and remove package files
     tree_clear_mock.assert_called_once_with(package_ahriman.base)
     build_queue_mock.assert_called_once_with(package_ahriman.base)
-    patches_mock.assert_called_once_with(package_ahriman.base)
+    patches_mock.assert_called_once_with(package_ahriman.base, [])
     status_client_mock.assert_called_once_with(package_ahriman.base)
 
 

--- a/tests/ahriman/core/test_tree.py
+++ b/tests/ahriman/core/test_tree.py
@@ -49,8 +49,7 @@ def test_leaf_load(package_ahriman: Package, repository_paths: RepositoryPaths,
     leaf = Leaf.load(package_ahriman, repository_paths, database)
     assert leaf.package == package_ahriman
     assert leaf.dependencies == {"ahriman-dependency"}
-    load_mock.assert_called_once_with(
-        pytest.helpers.anyvar(int), package_ahriman, None, repository_paths)
+    load_mock.assert_called_once_with(pytest.helpers.anyvar(int), package_ahriman, [], repository_paths)
     dependencies_mock.assert_called_once_with(pytest.helpers.anyvar(int))
 
 

--- a/tests/ahriman/models/test_pkgbuild_patch.py
+++ b/tests/ahriman/models/test_pkgbuild_patch.py
@@ -5,12 +5,29 @@ from unittest.mock import MagicMock, call
 from ahriman.models.pkgbuild_patch import PkgbuildPatch
 
 
+def test_post_init() -> None:
+    """
+    must remove empty keys
+    """
+    assert PkgbuildPatch("", "value").key is None
+    assert PkgbuildPatch(None, "value").key is None
+    assert PkgbuildPatch("key", "value").key == "key"
+
+
 def test_is_function() -> None:
     """
     must correctly define key as function
     """
     assert not PkgbuildPatch("key", "value").is_function
     assert PkgbuildPatch("key()", "value").is_function
+
+
+def test_is_plain_diff() -> None:
+    """
+    must correctly define key as function
+    """
+    assert not PkgbuildPatch("key", "value").is_plain_diff
+    assert PkgbuildPatch(None, "value").is_plain_diff
 
 
 def test_quote() -> None:
@@ -30,6 +47,13 @@ def test_serialize() -> None:
     assert PkgbuildPatch("key", "42").serialize() == "key=42"
     assert PkgbuildPatch("key", "4'2").serialize() == """key='4'"'"'2'"""
     assert PkgbuildPatch("key", "4'2", unsafe=True).serialize() == "key=4'2"
+
+
+def test_serialize_plain_diff() -> None:
+    """
+    must correctly serialize function values
+    """
+    assert PkgbuildPatch(None, "{ value }").serialize() == "{ value }"
 
 
 def test_serialize_function() -> None:


### PR DESCRIPTION
## Summary

This mr implements feature which will allow to patch PKGBUILD functions or variables instead of creating the full diff patch. 

Most of changes are backward-compatible except for renaming old `patch-add` function to `patch-set-add` and replacing the old function by new one with different argument list

Closes #60 

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
