### PR TITLE
replace several store_true keys to booleanoptionalaction alternative

### DIFF
--- a/src/ahriman/application/application/application.py
+++ b/src/ahriman/application/application/application.py
@@ -36,12 +36,12 @@ class Application(ApplicationPackages, ApplicationRepository):
             >>> from ahriman.models.package_source import PackageSource
             >>>
             >>> configuration = Configuration()
-            >>> application = Application("x86_64", configuration, no_report=False, unsafe=False)
+            >>> application = Application("x86_64", configuration, report=True, unsafe=False)
             >>> # add packages to build queue
             >>> application.add(["ahriman"], PackageSource.AUR, without_dependencies=False)
             >>>
             >>> # check for updates
-            >>> updates = application.updates([], no_aur=False, no_local=False, no_manual=False, no_vcs=False, log_fn=print)
+            >>> updates = application.updates([], aur=True, local=True, manual=True, vcs=True, log_fn=print)
             >>> # updates for specified packages
             >>> application.update(updates)
 

--- a/src/ahriman/application/application/application_properties.py
+++ b/src/ahriman/application/application/application_properties.py
@@ -34,15 +34,15 @@ class ApplicationProperties(LazyLogging):
         repository(Repository): repository instance
     """
 
-    def __init__(self, architecture: str, configuration: Configuration,
-                 no_report: bool, unsafe: bool, refresh_pacman_database: int = 0) -> None:
+    def __init__(self, architecture: str, configuration: Configuration, *,
+                 report: bool, unsafe: bool, refresh_pacman_database: int = 0) -> None:
         """
         default constructor
 
         Args:
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
             refresh_pacman_database(int): pacman database syncronization level, ``0`` is disabled
         """
@@ -50,4 +50,4 @@ class ApplicationProperties(LazyLogging):
         self.architecture = architecture
         self.database = SQLite.load(configuration)
         self.repository = Repository(architecture, configuration, self.database,
-                                     no_report, unsafe, refresh_pacman_database)
+                                     report=report, unsafe=unsafe, refresh_pacman_database=refresh_pacman_database)

--- a/src/ahriman/application/handlers/add.py
+++ b/src/ahriman/application/handlers/add.py
@@ -32,8 +32,8 @@ class Add(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -41,15 +41,17 @@ class Add(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe, args.refresh)
+        application = Application(architecture, configuration,
+                                  report=report, unsafe=unsafe, refresh_pacman_database=args.refresh)
         application.on_start()
         application.add(args.package, args.source, args.without_dependencies)
         if not args.now:
             return
 
-        packages = application.updates(args.package, True, True, False, True, application.logger.info)
+        packages = application.updates(args.package, aur=False, local=False, manual=True, vcs=False,
+                                       log_fn=application.logger.info)
         result = application.update(packages)
         Add.check_if_empty(args.exit_code, result.is_empty)

--- a/src/ahriman/application/handlers/backup.py
+++ b/src/ahriman/application/handlers/backup.py
@@ -37,8 +37,8 @@ class Backup(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False  # it should be called only as "no-architecture"
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -46,7 +46,7 @@ class Backup(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         backup_paths = Backup.get_paths(configuration)

--- a/src/ahriman/application/handlers/clean.py
+++ b/src/ahriman/application/handlers/clean.py
@@ -32,8 +32,8 @@ class Clean(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -41,9 +41,10 @@ class Clean(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         application.on_start()
-        application.clean(args.cache, args.chroot, args.manual, args.packages)
+        application.clean(cache=args.cache, chroot=args.chroot, manual=args.manual, packages=args.packages,
+                          pacman=args.pacman)

--- a/src/ahriman/application/handlers/daemon.py
+++ b/src/ahriman/application/handlers/daemon.py
@@ -32,8 +32,8 @@ class Daemon(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -41,11 +41,12 @@ class Daemon(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         from ahriman.application.handlers import Update
-        Update.run(args, architecture, configuration, no_report, unsafe)
-        timer = threading.Timer(args.interval, Daemon.run, (args, architecture, configuration, no_report, unsafe))
+        Update.run(args, architecture, configuration, report=report, unsafe=unsafe)
+        timer = threading.Timer(args.interval, Daemon.run, args=[args, architecture, configuration],
+                                kwargs={"report": report, "unsafe": unsafe})
         timer.start()
         timer.join()

--- a/src/ahriman/application/handlers/dump.py
+++ b/src/ahriman/application/handlers/dump.py
@@ -34,8 +34,8 @@ class Dump(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -43,7 +43,7 @@ class Dump(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         dump = configuration.dump()

--- a/src/ahriman/application/handlers/help.py
+++ b/src/ahriman/application/handlers/help.py
@@ -33,8 +33,8 @@ class Help(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False  # it should be called only as "no-architecture"
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -42,7 +42,7 @@ class Help(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         parser: argparse.ArgumentParser = args.parser()

--- a/src/ahriman/application/handlers/key_import.py
+++ b/src/ahriman/application/handlers/key_import.py
@@ -34,8 +34,8 @@ class KeyImport(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False  # it should be called only as "no-architecture"
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -43,8 +43,8 @@ class KeyImport(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         application.repository.sign.key_import(args.key_server, args.key)

--- a/src/ahriman/application/handlers/patch.py
+++ b/src/ahriman/application/handlers/patch.py
@@ -39,8 +39,8 @@ class Patch(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -48,10 +48,10 @@ class Patch(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         application.on_start()
 
         if args.action == Action.Update and args.variable is not None:

--- a/src/ahriman/application/handlers/rebuild.py
+++ b/src/ahriman/application/handlers/rebuild.py
@@ -34,8 +34,8 @@ class Rebuild(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -43,12 +43,12 @@ class Rebuild(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         depends_on = set(args.depends_on) if args.depends_on else None
 
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         application.on_start()
 
         if args.from_database:

--- a/src/ahriman/application/handlers/remove.py
+++ b/src/ahriman/application/handlers/remove.py
@@ -32,8 +32,8 @@ class Remove(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -41,9 +41,9 @@ class Remove(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         application.on_start()
         application.remove(args.package)

--- a/src/ahriman/application/handlers/remove_unknown.py
+++ b/src/ahriman/application/handlers/remove_unknown.py
@@ -33,8 +33,8 @@ class RemoveUnknown(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -42,16 +42,16 @@ class RemoveUnknown(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         application.on_start()
         unknown_packages = application.unknown()
 
         if args.dry_run:
             for package in sorted(unknown_packages):
-                StringPrinter(package).print(args.info)
+                StringPrinter(package).print(False)
             return
 
         application.remove(unknown_packages)

--- a/src/ahriman/application/handlers/restore.py
+++ b/src/ahriman/application/handlers/restore.py
@@ -34,8 +34,8 @@ class Restore(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False  # it should be called only as "no-architecture"
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -43,7 +43,7 @@ class Restore(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         with TarFile(args.path) as archive:

--- a/src/ahriman/application/handlers/shell.py
+++ b/src/ahriman/application/handlers/shell.py
@@ -38,8 +38,8 @@ class Shell(Handler):
     ALLOW_MULTI_ARCHITECTURE_RUN = False
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -47,11 +47,11 @@ class Shell(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         # pylint: disable=possibly-unused-variable
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         if args.verbose:
             # licensed by https://creativecommons.org/licenses/by-sa/3.0
             path = Path(sys.prefix) / "share" / "ahriman" / "templates" / "shell"

--- a/src/ahriman/application/handlers/sign.py
+++ b/src/ahriman/application/handlers/sign.py
@@ -32,8 +32,8 @@ class Sign(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -41,7 +41,7 @@ class Sign(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        Application(architecture, configuration, no_report, unsafe).sign(args.package)
+        Application(architecture, configuration, report=report, unsafe=unsafe).sign(args.package)

--- a/src/ahriman/application/handlers/status.py
+++ b/src/ahriman/application/handlers/status.py
@@ -37,8 +37,8 @@ class Status(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -46,11 +46,11 @@ class Status(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         # we are using reporter here
-        client = Application(architecture, configuration, no_report=False, unsafe=unsafe).repository.reporter
+        client = Application(architecture, configuration, report=True, unsafe=unsafe).repository.reporter
         if args.ahriman:
             service_status = client.get_internal()
             StatusPrinter(service_status.status).print(args.info)

--- a/src/ahriman/application/handlers/status_update.py
+++ b/src/ahriman/application/handlers/status_update.py
@@ -35,8 +35,8 @@ class StatusUpdate(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -44,11 +44,11 @@ class StatusUpdate(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         # we are using reporter here
-        client = Application(architecture, configuration, no_report=False, unsafe=unsafe).repository.reporter
+        client = Application(architecture, configuration, report=True, unsafe=unsafe).repository.reporter
 
         if args.action == Action.Update and args.package:
             # update packages statuses

--- a/src/ahriman/application/handlers/triggers.py
+++ b/src/ahriman/application/handlers/triggers.py
@@ -33,8 +33,8 @@ class Triggers(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -42,10 +42,10 @@ class Triggers(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe)
         if args.trigger:
             loader = application.repository.triggers
             loader.triggers = [loader.load_trigger(trigger) for trigger in args.trigger]

--- a/src/ahriman/application/handlers/unsafe_commands.py
+++ b/src/ahriman/application/handlers/unsafe_commands.py
@@ -35,8 +35,8 @@ class UnsafeCommands(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False  # it should be called only as "no-architecture"
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -44,7 +44,7 @@ class UnsafeCommands(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         parser = args.parser()
@@ -79,6 +79,7 @@ class UnsafeCommands(Handler):
         Returns:
             List[str]: list of commands with default unsafe flag
         """
+        # should never fail
         # pylint: disable=protected-access
         subparser = next(action for action in parser._actions if isinstance(action, argparse._SubParsersAction))
         return [action_name for action_name, action in subparser.choices.items() if action.get_default("unsafe")]

--- a/src/ahriman/application/handlers/update.py
+++ b/src/ahriman/application/handlers/update.py
@@ -32,8 +32,8 @@ class Update(Handler):
     """
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -41,13 +41,14 @@ class Update(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
-        application = Application(architecture, configuration, no_report, unsafe, args.refresh)
+        application = Application(architecture, configuration, report=report, unsafe=unsafe,
+                                  refresh_pacman_database=args.refresh)
         application.on_start()
-        packages = application.updates(args.package, args.no_aur, args.no_local, args.no_manual, args.no_vcs,
-                                       Update.log_fn(application, args.dry_run))
+        packages = application.updates(args.package, aur=args.aur, local=args.local, manual=args.manual, vcs=args.vcs,
+                                       log_fn=Update.log_fn(application, args.dry_run))
         Update.check_if_empty(args.exit_code, not packages)
         if args.dry_run:
             return

--- a/src/ahriman/application/handlers/users.py
+++ b/src/ahriman/application/handlers/users.py
@@ -39,8 +39,8 @@ class Users(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False  # it should be called only as "no-architecture"
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -48,7 +48,7 @@ class Users(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         database = SQLite.load(configuration)

--- a/src/ahriman/application/handlers/versions.py
+++ b/src/ahriman/application/handlers/versions.py
@@ -37,8 +37,8 @@ class Versions(Handler):
     ALLOW_AUTO_ARCHITECTURE_RUN = False  # it should be called only as "no-architecture"
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -46,7 +46,7 @@ class Versions(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         VersionPrinter(f"Module version {version.__version__}",

--- a/src/ahriman/application/handlers/web.py
+++ b/src/ahriman/application/handlers/web.py
@@ -35,8 +35,8 @@ class Web(Handler):
     ALLOW_MULTI_ARCHITECTURE_RUN = False  # required to be able to spawn external processes
 
     @classmethod
-    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str,
-            configuration: Configuration, no_report: bool, unsafe: bool) -> None:
+    def run(cls: Type[Handler], args: argparse.Namespace, architecture: str, configuration: Configuration, *,
+            report: bool, unsafe: bool) -> None:
         """
         callback for command line
 
@@ -44,7 +44,7 @@ class Web(Handler):
             args(argparse.Namespace): command line args
             architecture(str): repository architecture
             configuration(Configuration): configuration instance
-            no_report(bool): force disable reporting
+            report(bool): force enable or disable reporting
             unsafe(bool): if set no user check will be performed before path creation
         """
         # we are using local import for optional dependencies

--- a/src/ahriman/application/lock.py
+++ b/src/ahriman/application/lock.py
@@ -27,7 +27,7 @@ from typing import Literal, Optional, Type
 
 from ahriman import version
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import DuplicateRun
+from ahriman.core.exceptions import DuplicateRunError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.core.status.client import Client
 from ahriman.core.util import check_user
@@ -73,7 +73,7 @@ class Lock(LazyLogging):
         self.unsafe = args.unsafe
 
         self.paths = configuration.repository_paths
-        self.reporter = Client() if args.no_report else Client.load(configuration)
+        self.reporter = Client.load(configuration) if args.report else Client()
 
     def __enter__(self) -> Lock:
         """
@@ -122,7 +122,7 @@ class Lock(LazyLogging):
         """
         check if current user is actually owner of ahriman root
         """
-        check_user(self.paths, self.unsafe)
+        check_user(self.paths, unsafe=self.unsafe)
 
     def clear(self) -> None:
         """
@@ -144,4 +144,4 @@ class Lock(LazyLogging):
         try:
             self.path.touch(exist_ok=self.force)
         except FileExistsError:
-            raise DuplicateRun()
+            raise DuplicateRunError()

--- a/src/ahriman/core/alpm/remote/official_syncdb.py
+++ b/src/ahriman/core/alpm/remote/official_syncdb.py
@@ -19,6 +19,7 @@
 #
 from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.remote import Official
+from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.aur_package import AURPackage
 
 
@@ -48,4 +49,7 @@ class OfficialSyncdb(Official):
         Returns:
             AURPackage: package which match the package name
         """
-        return next(AURPackage.from_pacman(package) for package in pacman.package_get(package_name))
+        try:
+            return next(AURPackage.from_pacman(package) for package in pacman.package_get(package_name))
+        except StopIteration:
+            raise UnknownPackageError(package_name)

--- a/src/ahriman/core/alpm/repo.py
+++ b/src/ahriman/core/alpm/repo.py
@@ -20,7 +20,7 @@
 from pathlib import Path
 from typing import List
 
-from ahriman.core.exceptions import BuildFailed
+from ahriman.core.exceptions import BuildError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.core.util import check_output
 from ahriman.models.repository_paths import RepositoryPaths
@@ -72,7 +72,7 @@ class Repo(LazyLogging):
         """
         Repo._check_output(
             "repo-add", *self.sign_args, "-R", str(self.repo_path), str(path),
-            exception=BuildFailed(path.name),
+            exception=BuildError(path.name),
             cwd=self.paths.repository,
             logger=self.logger,
             user=self.uid)
@@ -103,7 +103,7 @@ class Repo(LazyLogging):
         # remove package from registry
         Repo._check_output(
             "repo-remove", *self.sign_args, str(self.repo_path), package,
-            exception=BuildFailed(package),
+            exception=BuildError(package),
             cwd=self.paths.repository,
             logger=self.logger,
             user=self.uid)

--- a/src/ahriman/core/auth/oauth.py
+++ b/src/ahriman/core/auth/oauth.py
@@ -24,7 +24,7 @@ from typing import Optional, Type
 from ahriman.core.auth import Mapping
 from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
-from ahriman.core.exceptions import InvalidOption
+from ahriman.core.exceptions import OptionError
 from ahriman.models.auth_settings import AuthSettings
 
 
@@ -91,7 +91,7 @@ class OAuth(Mapping):
         except TypeError:  # what if it is random string?
             is_oauth2_client = False
         if not is_oauth2_client:
-            raise InvalidOption(name)
+            raise OptionError(name)
         return provider
 
     def get_client(self) -> aioauth_client.OAuth2Client:

--- a/src/ahriman/core/build_tools/task.py
+++ b/src/ahriman/core/build_tools/task.py
@@ -23,7 +23,7 @@ from typing import List
 from ahriman.core.build_tools.sources import Sources
 from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
-from ahriman.core.exceptions import BuildFailed
+from ahriman.core.exceptions import BuildError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.core.util import check_output
 from ahriman.models.package import Package
@@ -78,14 +78,14 @@ class Task(LazyLogging):
 
         Task._check_output(
             *command,
-            exception=BuildFailed(self.package.base),
+            exception=BuildError(self.package.base),
             cwd=sources_dir,
             logger=self.logger,
             user=self.uid)
 
         # well it is not actually correct, but we can deal with it
         packages = Task._check_output("makepkg", "--packagelist",
-                                      exception=BuildFailed(self.package.base),
+                                      exception=BuildError(self.package.base),
                                       cwd=sources_dir,
                                       logger=self.logger).splitlines()
         return [Path(package) for package in packages]

--- a/src/ahriman/core/configuration.py
+++ b/src/ahriman/core/configuration.py
@@ -27,7 +27,7 @@ from logging.config import fileConfig
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type
 
-from ahriman.core.exceptions import InitializeException
+from ahriman.core.exceptions import InitializeError
 from ahriman.models.repository_paths import RepositoryPaths
 
 
@@ -208,7 +208,7 @@ class Configuration(configparser.RawConfigParser):
             InitializeException: in case if architecture and/or path are not set
         """
         if self.path is None or self.architecture is None:
-            raise InitializeException("Configuration path and/or architecture are not set")
+            raise InitializeError("Configuration path and/or architecture are not set")
         return self.path, self.architecture
 
     def dump(self) -> Dict[str, Dict[str, str]]:

--- a/src/ahriman/core/database/operations/operations.py
+++ b/src/ahriman/core/database/operations/operations.py
@@ -61,7 +61,7 @@ class Operations(LazyLogging):
             result[column[0]] = row[index]
         return result
 
-    def with_connection(self, query: Callable[[sqlite3.Connection], T], commit: bool = False) -> T:
+    def with_connection(self, query: Callable[[sqlite3.Connection], T], *, commit: bool = False) -> T:
         """
         perform operation in connection
 

--- a/src/ahriman/core/exceptions.py
+++ b/src/ahriman/core/exceptions.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any
 
 
-class BuildFailed(RuntimeError):
+class BuildError(RuntimeError):
     """
     base exception for failed builds
     """
@@ -36,7 +36,7 @@ class BuildFailed(RuntimeError):
         RuntimeError.__init__(self, f"Package {package_base} build failed, check logs for details")
 
 
-class DuplicateRun(RuntimeError):
+class DuplicateRunError(RuntimeError):
     """
     exception which will be raised if there is another application instance
     """
@@ -55,7 +55,13 @@ class ExitCode(RuntimeError):
     """
 
 
-class GitRemoteFailed(RuntimeError):
+class ExtensionError(RuntimeError):
+    """
+    exception being raised by trigger load in case of errors
+    """
+
+
+class GitRemoteError(RuntimeError):
     """
     git remote exception
     """
@@ -67,7 +73,7 @@ class GitRemoteFailed(RuntimeError):
         RuntimeError.__init__(self, "Git remote failed")
 
 
-class InitializeException(RuntimeError):
+class InitializeError(RuntimeError):
     """
     base service initialization exception
     """
@@ -80,58 +86,6 @@ class InitializeException(RuntimeError):
             details(str): details of the exception
         """
         RuntimeError.__init__(self, f"Could not load service: {details}")
-
-
-class InvalidExtension(RuntimeError):
-    """
-    exception being raised by trigger load in case of errors
-    """
-
-
-class InvalidOption(ValueError):
-    """
-    exception which will be raised on configuration errors
-    """
-
-    def __init__(self, value: Any) -> None:
-        """
-        default constructor
-
-        Args:
-            value(Any): option value
-        """
-        ValueError.__init__(self, f"Invalid or unknown option value `{value}`")
-
-
-class InvalidPath(ValueError):
-    """
-    exception which will be raised on path which is not belong to root directory
-    """
-
-    def __init__(self, path: Path, root: Path) -> None:
-        """
-        default constructor
-
-        Args:
-            path(Path): path which raised an exception
-            root(Path): repository root (i.e. ahriman home)
-        """
-        ValueError.__init__(self, f"Path `{path}` does not belong to repository root `{root}`")
-
-
-class InvalidPackageInfo(RuntimeError):
-    """
-    exception which will be raised on package load errors
-    """
-
-    def __init__(self, details: Any) -> None:
-        """
-        default constructor
-
-        Args:
-            details(Any): error details
-        """
-        RuntimeError.__init__(self, f"There are errors during reading package information: `{details}`")
 
 
 class MigrationError(RuntimeError):
@@ -149,7 +103,7 @@ class MigrationError(RuntimeError):
         RuntimeError.__init__(self, details)
 
 
-class MissingArchitecture(ValueError):
+class MissingArchitectureError(ValueError):
     """
     exception which will be raised if architecture is required, but missing
     """
@@ -164,7 +118,7 @@ class MissingArchitecture(ValueError):
         ValueError.__init__(self, f"Architecture required for subcommand {command}, but missing")
 
 
-class MultipleArchitectures(ValueError):
+class MultipleArchitecturesError(ValueError):
     """
     exception which will be raised if multiple architectures are not supported by the handler
     """
@@ -179,7 +133,53 @@ class MultipleArchitectures(ValueError):
         ValueError.__init__(self, f"Multiple architectures are not supported by subcommand {command}")
 
 
-class ReportFailed(RuntimeError):
+class OptionError(ValueError):
+    """
+    exception which will be raised on configuration errors
+    """
+
+    def __init__(self, value: Any) -> None:
+        """
+        default constructor
+
+        Args:
+            value(Any): option value
+        """
+        ValueError.__init__(self, f"Invalid or unknown option value `{value}`")
+
+
+class PackageInfoError(RuntimeError):
+    """
+    exception which will be raised on package load errors
+    """
+
+    def __init__(self, details: Any) -> None:
+        """
+        default constructor
+
+        Args:
+            details(Any): error details
+        """
+        RuntimeError.__init__(self, f"There are errors during reading package information: `{details}`")
+
+
+class PathError(ValueError):
+    """
+    exception which will be raised on path which is not belong to root directory
+    """
+
+    def __init__(self, path: Path, root: Path) -> None:
+        """
+        default constructor
+
+        Args:
+            path(Path): path which raised an exception
+            root(Path): repository root (i.e. ahriman home)
+        """
+        ValueError.__init__(self, f"Path `{path}` does not belong to repository root `{root}`")
+
+
+class ReportError(RuntimeError):
     """
     report generation exception
     """
@@ -191,22 +191,7 @@ class ReportFailed(RuntimeError):
         RuntimeError.__init__(self, "Report failed")
 
 
-class SuccessFailed(ValueError):
-    """
-    exception for merging invalid statues
-    """
-
-    def __init__(self, package_base: str) -> None:
-        """
-        default constructor
-
-        Args:
-            package_base(str): package base name
-        """
-        ValueError.__init__(self, f"Package base {package_base} had status failed, but new status is success")
-
-
-class SyncFailed(RuntimeError):
+class SynchronizationError(RuntimeError):
     """
     remote synchronization exception
     """
@@ -218,7 +203,7 @@ class SyncFailed(RuntimeError):
         RuntimeError.__init__(self, "Sync failed")
 
 
-class UnknownPackage(ValueError):
+class UnknownPackageError(ValueError):
     """
     exception for status watcher which will be thrown on unknown package
     """
@@ -233,7 +218,22 @@ class UnknownPackage(ValueError):
         ValueError.__init__(self, f"Package base {package_base} is unknown")
 
 
-class UnsafeRun(RuntimeError):
+class UnprocessedPackageStatusError(ValueError):
+    """
+    exception for merging invalid statues
+    """
+
+    def __init__(self, package_base: str) -> None:
+        """
+        default constructor
+
+        Args:
+            package_base(str): package base name
+        """
+        ValueError.__init__(self, f"Package base {package_base} had status failed, but new status is success")
+
+
+class UnsafeRunError(RuntimeError):
     """
     exception which will be raised in case if user is not owner of repository
     """

--- a/src/ahriman/core/gitremote/remote_pull.py
+++ b/src/ahriman/core/gitremote/remote_pull.py
@@ -24,7 +24,7 @@ from tempfile import TemporaryDirectory
 
 from ahriman.core.build_tools.sources import Sources
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import GitRemoteFailed
+from ahriman.core.exceptions import GitRemoteError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.core.util import walk
 from ahriman.models.package_source import PackageSource
@@ -87,4 +87,4 @@ class RemotePull(LazyLogging):
             self.repo_clone()
         except Exception:
             self.logger.exception("git pull failed")
-            raise GitRemoteFailed()
+            raise GitRemoteError()

--- a/src/ahriman/core/gitremote/remote_push.py
+++ b/src/ahriman/core/gitremote/remote_push.py
@@ -25,7 +25,7 @@ from typing import Generator
 
 from ahriman.core.build_tools.sources import Sources
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import GitRemoteFailed
+from ahriman.core.exceptions import GitRemoteError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.models.package import Package
 from ahriman.models.package_source import PackageSource
@@ -110,4 +110,4 @@ class RemotePush(LazyLogging):
                 Sources.push(clone_dir, self.remote_source, *RemotePush.packages_update(result, clone_dir))
         except Exception:
             self.logger.exception("git push failed")
-            raise GitRemoteFailed()
+            raise GitRemoteError()

--- a/src/ahriman/core/report/report.py
+++ b/src/ahriman/core/report/report.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Iterable, Type
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import ReportFailed
+from ahriman.core.exceptions import ReportError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.models.package import Package
 from ahriman.models.report_settings import ReportSettings
@@ -121,4 +121,4 @@ class Report(LazyLogging):
             self.generate(packages, result)
         except Exception:
             self.logger.exception("report generation failed")
-            raise ReportFailed()
+            raise ReportError()

--- a/src/ahriman/core/repository/cleaner.py
+++ b/src/ahriman/core/repository/cleaner.py
@@ -66,6 +66,14 @@ class Cleaner(RepositoryProperties):
         for package in self.packages_built():
             package.unlink()
 
+    def clear_pacman(self) -> None:
+        """
+        clear directory with pacman databases
+        """
+        self.logger.info("clear pacman database directory")
+        for pacman in self.paths.pacman.iterdir():
+            shutil.rmtree(pacman)
+
     def clear_queue(self) -> None:
         """
         clear packages which were queued for the update

--- a/src/ahriman/core/repository/executor.py
+++ b/src/ahriman/core/repository/executor.py
@@ -21,7 +21,7 @@ import shutil
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterable, List, Optional, Set
+from typing import Iterable, List, Optional
 
 from ahriman.core.build_tools.task import Task
 from ahriman.core.repository.cleaner import Cleaner
@@ -187,8 +187,12 @@ class Executor(Cleaner):
                 self.reporter.set_success(local)
                 result.add_success(local)
 
-                current_package_archives: Set[str] = next(
-                    (set(current.packages) for current in current_packages if current.base == local.base), set())
+                current_package_archives = {
+                    package
+                    for current in current_packages
+                    if current.base == local.base
+                    for package in current.packages
+                }
                 removed_packages.extend(current_package_archives.difference(local.packages))
             except Exception:
                 self.reporter.set_failed(local.base)

--- a/src/ahriman/core/repository/repository.py
+++ b/src/ahriman/core/repository/repository.py
@@ -39,7 +39,7 @@ class Repository(Executor, UpdateHandler):
             >>>
             >>> configuration = Configuration()
             >>> database = SQLite.load(configuration)
-            >>> repository = Repository("x86_64", configuration, database, no_report=False, unsafe=False)
+            >>> repository = Repository("x86_64", configuration, database, report=True, unsafe=False)
             >>> known_packages = repository.packages()
             >>>
             >>> build_result = repository.process_build(known_packages)

--- a/src/ahriman/core/repository/update_handler.py
+++ b/src/ahriman/core/repository/update_handler.py
@@ -42,13 +42,13 @@ class UpdateHandler(Cleaner):
         """
         raise NotImplementedError
 
-    def updates_aur(self, filter_packages: Iterable[str], no_vcs: bool) -> List[Package]:
+    def updates_aur(self, filter_packages: Iterable[str], *, vcs: bool) -> List[Package]:
         """
         check AUR for updates
 
         Args:
             filter_packages(Iterable[str]): do not check every package just specified in the list
-            no_vcs(bool): do not check VCS packages
+            vcs(bool): enable or disable checking of VCS packages
 
         Returns:
             List[Package]: list of packages which are out-of-dated
@@ -58,7 +58,7 @@ class UpdateHandler(Cleaner):
         for local in self.packages():
             if local.base in self.ignore_list:
                 continue
-            if local.is_vcs and no_vcs:
+            if local.is_vcs and not vcs:
                 continue
             if filter_packages and local.base not in filter_packages:
                 continue

--- a/src/ahriman/core/sign/gpg.py
+++ b/src/ahriman/core/sign/gpg.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import List, Optional, Set, Tuple
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import BuildFailed
+from ahriman.core.exceptions import BuildError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.core.util import check_output, exception_response_text
 from ahriman.models.sign_settings import SignSettings
@@ -153,7 +153,7 @@ class GPG(LazyLogging):
         """
         GPG._check_output(
             *GPG.sign_command(path, key),
-            exception=BuildFailed(path.name),
+            exception=BuildError(path.name),
             logger=self.logger)
         return [path, path.parent / f"{path.name}.sig"]
 

--- a/src/ahriman/core/spawn.py
+++ b/src/ahriman/core/spawn.py
@@ -78,7 +78,7 @@ class Spawn(Thread, LazyLogging):
         result = callback(args, architecture)
         queue.put((process_id, result))
 
-    def packages_add(self, packages: Iterable[str], now: bool) -> None:
+    def packages_add(self, packages: Iterable[str], *, now: bool) -> None:
         """
         add packages
 

--- a/src/ahriman/core/status/watcher.py
+++ b/src/ahriman/core/status/watcher.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Optional, Tuple
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
-from ahriman.core.exceptions import UnknownPackage
+from ahriman.core.exceptions import UnknownPackageError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.core.repository import Repository
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
@@ -52,7 +52,7 @@ class Watcher(LazyLogging):
         """
         self.architecture = architecture
         self.database = database
-        self.repository = Repository(architecture, configuration, database, no_report=True, unsafe=False)
+        self.repository = Repository(architecture, configuration, database, report=False, unsafe=False)
 
         self.known: Dict[str, Tuple[Package, BuildStatus]] = {}
         self.status = BuildStatus()
@@ -83,7 +83,7 @@ class Watcher(LazyLogging):
         try:
             return self.known[base]
         except KeyError:
-            raise UnknownPackage(base)
+            raise UnknownPackageError(base)
 
     def load(self) -> None:
         """
@@ -127,7 +127,7 @@ class Watcher(LazyLogging):
             try:
                 package, _ = self.known[package_base]
             except KeyError:
-                raise UnknownPackage(package_base)
+                raise UnknownPackageError(package_base)
         full_status = BuildStatus(status)
         self.known[package_base] = (package, full_status)
         self.database.package_update(package, full_status)

--- a/src/ahriman/core/tree.py
+++ b/src/ahriman/core/tree.py
@@ -110,7 +110,7 @@ class Tree:
             >>>
             >>> configuration = Configuration()
             >>> database = SQLite.load(configuration)
-            >>> repository = Repository("x86_64", configuration, database, no_report=False, unsafe=False)
+            >>> repository = Repository("x86_64", configuration, database, report=True, unsafe=False)
             >>> packages = repository.packages()
             >>>
             >>> tree = Tree.load(packages, configuration.repository_paths, database)

--- a/src/ahriman/core/triggers/trigger_loader.py
+++ b/src/ahriman/core/triggers/trigger_loader.py
@@ -26,7 +26,7 @@ from types import ModuleType
 from typing import Generator, Iterable
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import InvalidExtension
+from ahriman.core.exceptions import ExtensionError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.core.triggers import Trigger
 from ahriman.models.package import Package
@@ -136,7 +136,7 @@ class TriggerLoader(LazyLogging):
         try:
             return importlib.import_module(package)
         except ModuleNotFoundError:
-            raise InvalidExtension(f"Module {package} not found")
+            raise ExtensionError(f"Module {package} not found")
 
     def load_trigger(self, module_path: str) -> Trigger:
         """
@@ -163,15 +163,15 @@ class TriggerLoader(LazyLogging):
 
         trigger_type = getattr(module, class_name, None)
         if not isinstance(trigger_type, type):
-            raise InvalidExtension(f"{class_name} of {package_or_path} is not a type")
+            raise ExtensionError(f"{class_name} of {package_or_path} is not a type")
         self.logger.info("loaded type %s of package %s", class_name, package_or_path)
 
         try:
             trigger = trigger_type(self.architecture, self.configuration)
         except Exception:
-            raise InvalidExtension(f"Could not load instance of trigger from {class_name} of {package_or_path}")
+            raise ExtensionError(f"Could not load instance of trigger from {class_name} of {package_or_path}")
         if not isinstance(trigger, Trigger):
-            raise InvalidExtension(f"Class {class_name} of {package_or_path} is not a Trigger")
+            raise ExtensionError(f"Class {class_name} of {package_or_path} is not a Trigger")
 
         return trigger
 

--- a/src/ahriman/core/upload/upload.py
+++ b/src/ahriman/core/upload/upload.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Iterable, Type
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import SyncFailed
+from ahriman.core.exceptions import SynchronizationError
 from ahriman.core.lazy_logging import LazyLogging
 from ahriman.models.package import Package
 from ahriman.models.upload_settings import UploadSettings
@@ -108,7 +108,7 @@ class Upload(LazyLogging):
             self.sync(path, built_packages)
         except Exception:
             self.logger.exception("remote sync failed")
-            raise SyncFailed()
+            raise SynchronizationError()
 
     def sync(self, path: Path, built_packages: Iterable[Package]) -> None:
         """

--- a/src/ahriman/core/util.py
+++ b/src/ahriman/core/util.py
@@ -29,7 +29,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Any, Dict, Generator, IO, Iterable, List, Optional, Type, Union
 
-from ahriman.core.exceptions import InvalidOption, UnsafeRun
+from ahriman.core.exceptions import OptionError, UnsafeRunError
 from ahriman.models.repository_paths import RepositoryPaths
 
 
@@ -114,7 +114,7 @@ def check_output(*args: str, exception: Optional[Exception], cwd: Optional[Path]
         return "\n".join(result)
 
 
-def check_user(paths: RepositoryPaths, unsafe: bool) -> None:
+def check_user(paths: RepositoryPaths, *, unsafe: bool) -> None:
     """
     check if current user is the owner of the root
 
@@ -137,7 +137,7 @@ def check_user(paths: RepositoryPaths, unsafe: bool) -> None:
     current_uid = os.getuid()
     root_uid, _ = paths.root_owner
     if current_uid != root_uid:
-        raise UnsafeRun(current_uid, root_uid)
+        raise UnsafeRunError(current_uid, root_uid)
 
 
 def enum_values(enum: Type[Enum]) -> List[str]:
@@ -261,7 +261,7 @@ def pretty_size(size: Optional[float], level: int = 0) -> str:
             return "MiB"
         if level == 3:
             return "GiB"
-        raise InvalidOption(level)  # must never happen actually
+        raise OptionError(level)  # must never happen actually
 
     if size is None:
         return ""

--- a/src/ahriman/models/repository_paths.py
+++ b/src/ahriman/models/repository_paths.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Set, Tuple, Type
 
-from ahriman.core.exceptions import InvalidPath
+from ahriman.core.exceptions import PathError
 
 
 @dataclass(frozen=True)
@@ -178,7 +178,7 @@ class RepositoryPaths:
             os.chown(current, root_uid, root_gid, follow_symlinks=False)
 
         if self.root not in path.parents:
-            raise InvalidPath(path, self.root)
+            raise PathError(path, self.root)
         root_uid, root_gid = self.root_owner
         while path != self.root:
             set_owner(path)

--- a/src/ahriman/models/result.py
+++ b/src/ahriman/models/result.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Iterable
 
-from ahriman.core.exceptions import SuccessFailed
+from ahriman.core.exceptions import UnprocessedPackageStatusError
 from ahriman.models.package import Package
 
 
@@ -111,7 +111,7 @@ class Result:
             self.add_failed(package)
         for base, package in other._success.items():
             if base in self._failed:
-                raise SuccessFailed(base)
+                raise UnprocessedPackageStatusError(base)
             self.add_success(package)
         return self
 

--- a/src/ahriman/web/views/status/package.py
+++ b/src/ahriman/web/views/status/package.py
@@ -19,7 +19,7 @@
 #
 from aiohttp.web import HTTPBadRequest, HTTPNoContent, HTTPNotFound, Response, json_response
 
-from ahriman.core.exceptions import UnknownPackage
+from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.build_status import BuildStatusEnum
 from ahriman.models.package import Package
 from ahriman.models.user_access import UserAccess
@@ -54,7 +54,7 @@ class PackageView(BaseView):
 
         try:
             package, status = self.service.get(base)
-        except UnknownPackage:
+        except UnknownPackageError:
             raise HTTPNotFound()
 
         response = [
@@ -104,7 +104,7 @@ class PackageView(BaseView):
 
         try:
             self.service.update(base, status, package)
-        except UnknownPackage:
+        except UnknownPackageError:
             raise HTTPBadRequest(reason=f"Package {base} is unknown, but no package body set")
 
         raise HTTPNoContent()

--- a/src/ahriman/web/web.py
+++ b/src/ahriman/web/web.py
@@ -26,7 +26,7 @@ from aiohttp import web
 from ahriman.core.auth import Auth
 from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
-from ahriman.core.exceptions import InitializeException
+from ahriman.core.exceptions import InitializeError
 from ahriman.core.spawn import Spawn
 from ahriman.core.status.watcher import Watcher
 from ahriman.web.middlewares.exception_handler import exception_handler
@@ -62,7 +62,7 @@ async def on_startup(application: web.Application) -> None:
     except Exception:
         message = "could not load packages"
         application.logger.exception(message)
-        raise InitializeException(message)
+        raise InitializeError(message)
 
 
 def run_server(application: web.Application) -> None:

--- a/tests/ahriman/application/application/conftest.py
+++ b/tests/ahriman/application/application/conftest.py
@@ -24,7 +24,7 @@ def application_packages(configuration: Configuration, database: SQLite, mocker:
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     mocker.patch("ahriman.core.database.SQLite.load", return_value=database)
-    return ApplicationPackages("x86_64", configuration, no_report=True, unsafe=False)
+    return ApplicationPackages("x86_64", configuration, report=False, unsafe=False)
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def application_properties(configuration: Configuration, database: SQLite,
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     mocker.patch("ahriman.core.database.SQLite.load", return_value=database)
-    return ApplicationProperties("x86_64", configuration, no_report=True, unsafe=False)
+    return ApplicationProperties("x86_64", configuration, report=False, unsafe=False)
 
 
 @pytest.fixture
@@ -62,4 +62,4 @@ def application_repository(configuration: Configuration, database: SQLite,
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     mocker.patch("ahriman.core.database.SQLite.load", return_value=database)
-    return ApplicationRepository("x86_64", configuration, no_report=True, unsafe=False)
+    return ApplicationRepository("x86_64", configuration, report=False, unsafe=False)

--- a/tests/ahriman/application/conftest.py
+++ b/tests/ahriman/application/conftest.py
@@ -25,7 +25,7 @@ def application(configuration: Configuration, database: SQLite, mocker: MockerFi
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     mocker.patch("ahriman.core.database.SQLite.load", return_value=database)
-    return Application("x86_64", configuration, no_report=True, unsafe=False)
+    return Application("x86_64", configuration, report=False, unsafe=False)
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def args() -> argparse.Namespace:
     Returns:
         argparse.Namespace: command line arguments test instance
     """
-    return argparse.Namespace(architecture=None, lock=None, force=False, unsafe=False, no_report=True)
+    return argparse.Namespace(architecture=None, lock=None, force=False, unsafe=False, report=False)
 
 
 @pytest.fixture

--- a/tests/ahriman/application/handlers/test_handler.py
+++ b/tests/ahriman/application/handlers/test_handler.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 
 from ahriman.application.handlers import Handler
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import ExitCode, MissingArchitecture, MultipleArchitectures
+from ahriman.core.exceptions import ExitCode, MissingArchitectureError, MultipleArchitecturesError
 
 
 def test_architectures_extract(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
@@ -29,7 +29,7 @@ def test_architectures_extract_empty(args: argparse.Namespace, configuration: Co
     args.configuration = configuration.path
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.known_architectures", return_value=set())
 
-    with pytest.raises(MissingArchitecture):
+    with pytest.raises(MissingArchitectureError):
         Handler.architectures_extract(args)
 
 
@@ -39,7 +39,7 @@ def test_architectures_extract_exception(args: argparse.Namespace, mocker: Mocke
     """
     args.command = "config"
     mocker.patch.object(Handler, "ALLOW_AUTO_ARCHITECTURE_RUN", False)
-    with pytest.raises(MissingArchitecture):
+    with pytest.raises(MissingArchitectureError):
         Handler.architectures_extract(args)
 
 
@@ -112,7 +112,7 @@ def test_execute_multiple_not_supported(args: argparse.Namespace, mocker: Mocker
     args.command = "web"
     mocker.patch.object(Handler, "ALLOW_MULTI_ARCHITECTURE_RUN", False)
 
-    with pytest.raises(MultipleArchitectures):
+    with pytest.raises(MultipleArchitecturesError):
         Handler.execute(args)
 
 
@@ -135,7 +135,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration) -> None:
     must raise NotImplemented for missing method
     """
     with pytest.raises(NotImplementedError):
-        Handler.run(args, "x86_64", configuration, True, True)
+        Handler.run(args, "x86_64", configuration, report=True, unsafe=True)
 
 
 def test_check_if_empty() -> None:

--- a/tests/ahriman/application/handlers/test_handler_add.py
+++ b/tests/ahriman/application/handlers/test_handler_add.py
@@ -38,7 +38,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     application_mock = mocker.patch("ahriman.application.application.Application.add")
     on_start_mock = mocker.patch("ahriman.application.application.Application.on_start")
 
-    Add.run(args, "x86_64", configuration, True, False)
+    Add.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with(args.package, args.source, args.without_dependencies)
     on_start_mock.assert_called_once_with()
 
@@ -58,8 +58,9 @@ def test_run_with_updates(args: argparse.Namespace, configuration: Configuration
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
     updates_mock = mocker.patch("ahriman.application.application.Application.updates", return_value=[package_ahriman])
 
-    Add.run(args, "x86_64", configuration, True, False)
-    updates_mock.assert_called_once_with(args.package, True, True, False, True, pytest.helpers.anyvar(int))
+    Add.run(args, "x86_64", configuration, report=False, unsafe=False)
+    updates_mock.assert_called_once_with(args.package, aur=False, local=False, manual=True, vcs=False,
+                                         log_fn=pytest.helpers.anyvar(int))
     application_mock.assert_called_once_with([package_ahriman])
     check_mock.assert_called_once_with(False, False)
 
@@ -77,5 +78,5 @@ def test_run_empty_exception(args: argparse.Namespace, configuration: Configurat
     mocker.patch("ahriman.application.application.Application.updates")
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Add.run(args, "x86_64", configuration, True, False)
+    Add.run(args, "x86_64", configuration, report=False, unsafe=False)
     check_mock.assert_called_once_with(True, True)

--- a/tests/ahriman/application/handlers/test_handler_backup.py
+++ b/tests/ahriman/application/handlers/test_handler_backup.py
@@ -33,7 +33,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     add_mock = tarfile.__enter__.return_value = MagicMock()
     mocker.patch("tarfile.TarFile.__new__", return_value=tarfile)
 
-    Backup.run(args, "x86_64", configuration, True, False)
+    Backup.run(args, "x86_64", configuration, report=False, unsafe=False)
     add_mock.add.assert_called_once_with(Path("path"))
 
 

--- a/tests/ahriman/application/handlers/test_handler_clean.py
+++ b/tests/ahriman/application/handlers/test_handler_clean.py
@@ -20,6 +20,7 @@ def _default_args(args: argparse.Namespace) -> argparse.Namespace:
     args.chroot = False
     args.manual = False
     args.packages = False
+    args.pacman = False
     return args
 
 
@@ -32,6 +33,6 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     application_mock = mocker.patch("ahriman.application.application.Application.clean")
     on_start_mock = mocker.patch("ahriman.application.application.Application.on_start")
 
-    Clean.run(args, "x86_64", configuration, True, False)
-    application_mock.assert_called_once_with(False, False, False, False)
+    Clean.run(args, "x86_64", configuration, report=False, unsafe=False)
+    application_mock.assert_called_once_with(cache=False, chroot=False, manual=False, packages=False, pacman=False)
     on_start_mock.assert_called_once_with()

--- a/tests/ahriman/application/handlers/test_handler_daemon.py
+++ b/tests/ahriman/application/handlers/test_handler_daemon.py
@@ -17,10 +17,10 @@ def _default_args(args: argparse.Namespace) -> argparse.Namespace:
         argparse.Namespace: generated arguments for these test cases
     """
     args.interval = 60 * 60 * 12
-    args.no_aur = False
-    args.no_local = False
-    args.no_manual = False
-    args.no_vcs = False
+    args.aur = True
+    args.local = True
+    args.manual = True
+    args.vcs = True
     return args
 
 
@@ -33,8 +33,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     start_mock = mocker.patch("threading.Timer.start")
     join_mock = mocker.patch("threading.Timer.join")
 
-    Daemon.run(args, "x86_64", configuration, True, False)
-    Daemon._SHOULD_RUN = False
-    run_mock.assert_called_once_with(args, "x86_64", configuration, True, False)
+    Daemon.run(args, "x86_64", configuration, report=True, unsafe=False)
+    run_mock.assert_called_once_with(args, "x86_64", configuration, report=True, unsafe=False)
     start_mock.assert_called_once_with()
     join_mock.assert_called_once_with()

--- a/tests/ahriman/application/handlers/test_handler_dump.py
+++ b/tests/ahriman/application/handlers/test_handler_dump.py
@@ -15,7 +15,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     application_mock = mocker.patch("ahriman.core.configuration.Configuration.dump",
                                     return_value=configuration.dump())
 
-    Dump.run(args, "x86_64", configuration, True, False)
+    Dump.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with()
     print_mock.assert_called()
 

--- a/tests/ahriman/application/handlers/test_handler_help.py
+++ b/tests/ahriman/application/handlers/test_handler_help.py
@@ -29,7 +29,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     args = _default_args(args)
     parse_mock = mocker.patch("argparse.ArgumentParser.parse_args")
 
-    Help.run(args, "x86_64", configuration, True, False)
+    Help.run(args, "x86_64", configuration, report=False, unsafe=False)
     parse_mock.assert_called_once_with(["--help"])
 
 
@@ -41,7 +41,7 @@ def test_run_command(args: argparse.Namespace, configuration: Configuration, moc
     args.command = "aur-search"
     parse_mock = mocker.patch("argparse.ArgumentParser.parse_args")
 
-    Help.run(args, "x86_64", configuration, True, False)
+    Help.run(args, "x86_64", configuration, report=False, unsafe=False)
     parse_mock.assert_called_once_with(["aur-search", "--help"])
 
 

--- a/tests/ahriman/application/handlers/test_handler_key_import.py
+++ b/tests/ahriman/application/handlers/test_handler_key_import.py
@@ -29,7 +29,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_mock = mocker.patch("ahriman.core.sign.gpg.GPG.key_import")
 
-    KeyImport.run(args, "x86_64", configuration, True, False)
+    KeyImport.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with(args.key_server, args.key)
 
 

--- a/tests/ahriman/application/handlers/test_handler_patch.py
+++ b/tests/ahriman/application/handlers/test_handler_patch.py
@@ -42,7 +42,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
                               return_value=(args.package, PkgbuildPatch(None, "patch")))
     application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_create")
 
-    Patch.run(args, "x86_64", configuration, True, False)
+    Patch.run(args, "x86_64", configuration, report=False, unsafe=False)
     patch_mock.assert_called_once_with(args.package, args.track)
     application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, PkgbuildPatch(None, "patch"))
 
@@ -60,7 +60,7 @@ def test_run_function(args: argparse.Namespace, configuration: Configuration, mo
     patch_mock = mocker.patch("ahriman.application.handlers.Patch.patch_create_from_function", return_value=patch)
     application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_create")
 
-    Patch.run(args, "x86_64", configuration, True, False)
+    Patch.run(args, "x86_64", configuration, report=False, unsafe=False)
     patch_mock.assert_called_once_with(args.variable, args.patch)
     application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, patch)
 
@@ -75,7 +75,7 @@ def test_run_list(args: argparse.Namespace, configuration: Configuration, mocker
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_list")
 
-    Patch.run(args, "x86_64", configuration, True, False)
+    Patch.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, ["version"], False)
 
 
@@ -89,7 +89,7 @@ def test_run_remove(args: argparse.Namespace, configuration: Configuration, mock
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_mock = mocker.patch("ahriman.application.handlers.Patch.patch_set_remove")
 
-    Patch.run(args, "x86_64", configuration, True, False)
+    Patch.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with(pytest.helpers.anyvar(int), args.package, ["version"])
 
 

--- a/tests/ahriman/application/handlers/test_handler_rebuild.py
+++ b/tests/ahriman/application/handlers/test_handler_rebuild.py
@@ -2,7 +2,7 @@ import argparse
 import pytest
 
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.application.application import Application
 from ahriman.application.handlers import Rebuild
@@ -43,10 +43,10 @@ def test_run(args: argparse.Namespace, package_ahriman: Package,
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
     on_start_mock = mocker.patch("ahriman.application.application.Application.on_start")
 
-    Rebuild.run(args, "x86_64", configuration, True, False)
+    Rebuild.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_packages_mock.assert_called_once_with(None)
     application_mock.assert_called_once_with([package_ahriman])
-    check_mock.assert_has_calls([mock.call(False, False), mock.call(False, False)])
+    check_mock.assert_has_calls([MockCall(False, False), MockCall(False, False)])
     on_start_mock.assert_called_once_with()
 
 
@@ -61,7 +61,7 @@ def test_run_extract_packages(args: argparse.Namespace, configuration: Configura
     mocker.patch("ahriman.application.application.Application.add")
     extract_mock = mocker.patch("ahriman.application.handlers.Rebuild.extract_packages", return_value=[])
 
-    Rebuild.run(args, "x86_64", configuration, True, False)
+    Rebuild.run(args, "x86_64", configuration, report=False, unsafe=False)
     extract_mock.assert_called_once_with(pytest.helpers.anyvar(int))
 
 
@@ -77,7 +77,7 @@ def test_run_dry_run(args: argparse.Namespace, configuration: Configuration,
     application_mock = mocker.patch("ahriman.application.application.Application.update")
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Rebuild.run(args, "x86_64", configuration, True, False)
+    Rebuild.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_not_called()
     check_mock.assert_called_once_with(False, False)
 
@@ -92,7 +92,7 @@ def test_run_filter(args: argparse.Namespace, configuration: Configuration, mock
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_packages_mock = mocker.patch("ahriman.core.repository.repository.Repository.packages_depend_on")
 
-    Rebuild.run(args, "x86_64", configuration, True, False)
+    Rebuild.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_packages_mock.assert_called_once_with({"python-aur"})
 
 
@@ -105,7 +105,7 @@ def test_run_without_filter(args: argparse.Namespace, configuration: Configurati
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_packages_mock = mocker.patch("ahriman.core.repository.repository.Repository.packages_depend_on")
 
-    Rebuild.run(args, "x86_64", configuration, True, False)
+    Rebuild.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_packages_mock.assert_called_once_with(None)
 
 
@@ -121,7 +121,7 @@ def test_run_update_empty_exception(args: argparse.Namespace, configuration: Con
     mocker.patch("ahriman.core.repository.repository.Repository.packages_depend_on", return_value=[])
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Rebuild.run(args, "x86_64", configuration, True, False)
+    Rebuild.run(args, "x86_64", configuration, report=False, unsafe=False)
     check_mock.assert_called_once_with(True, True)
 
 
@@ -137,8 +137,8 @@ def test_run_build_empty_exception(args: argparse.Namespace, configuration: Conf
     mocker.patch("ahriman.application.application.Application.update", return_value=Result())
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Rebuild.run(args, "x86_64", configuration, True, False)
-    check_mock.assert_has_calls([mock.call(True, False), mock.call(True, True)])
+    Rebuild.run(args, "x86_64", configuration, report=False, unsafe=False)
+    check_mock.assert_has_calls([MockCall(True, False), MockCall(True, True)])
 
 
 def test_extract_packages(application: Application, mocker: MockerFixture) -> None:

--- a/tests/ahriman/application/handlers/test_handler_remove.py
+++ b/tests/ahriman/application/handlers/test_handler_remove.py
@@ -29,6 +29,6 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     application_mock = mocker.patch("ahriman.application.application.Application.remove")
     on_start_mock = mocker.patch("ahriman.application.application.Application.on_start")
 
-    Remove.run(args, "x86_64", configuration, True, False)
+    Remove.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with([])
     on_start_mock.assert_called_once_with()

--- a/tests/ahriman/application/handlers/test_handler_remove_unknown.py
+++ b/tests/ahriman/application/handlers/test_handler_remove_unknown.py
@@ -18,7 +18,6 @@ def _default_args(args: argparse.Namespace) -> argparse.Namespace:
         argparse.Namespace: generated arguments for these test cases
     """
     args.dry_run = False
-    args.info = False
     return args
 
 
@@ -34,7 +33,7 @@ def test_run(args: argparse.Namespace, package_ahriman: Package,
     remove_mock = mocker.patch("ahriman.application.application.Application.remove")
     on_start_mock = mocker.patch("ahriman.application.application.Application.on_start")
 
-    RemoveUnknown.run(args, "x86_64", configuration, True, False)
+    RemoveUnknown.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with()
     remove_mock.assert_called_once_with([package_ahriman])
     on_start_mock.assert_called_once_with()
@@ -53,27 +52,7 @@ def test_run_dry_run(args: argparse.Namespace, configuration: Configuration, pac
     remove_mock = mocker.patch("ahriman.application.application.Application.remove")
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
-    RemoveUnknown.run(args, "x86_64", configuration, True, False)
+    RemoveUnknown.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with()
     remove_mock.assert_not_called()
     print_mock.assert_called_once_with(False)
-
-
-def test_run_dry_run_verbose(args: argparse.Namespace, configuration: Configuration, package_ahriman: Package,
-                             mocker: MockerFixture) -> None:
-    """
-    must run simplified command with increased verbosity
-    """
-    args = _default_args(args)
-    args.dry_run = True
-    args.info = True
-    mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
-    application_mock = mocker.patch("ahriman.application.application.Application.unknown",
-                                    return_value=[package_ahriman])
-    remove_mock = mocker.patch("ahriman.application.application.Application.remove")
-    print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
-
-    RemoveUnknown.run(args, "x86_64", configuration, True, False)
-    application_mock.assert_called_once_with()
-    remove_mock.assert_not_called()
-    print_mock.assert_called_once_with(True)

--- a/tests/ahriman/application/handlers/test_handler_restore.py
+++ b/tests/ahriman/application/handlers/test_handler_restore.py
@@ -32,7 +32,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     extract_mock = tarfile.__enter__.return_value = MagicMock()
     mocker.patch("tarfile.TarFile.__new__", return_value=tarfile)
 
-    Restore.run(args, "x86_64", configuration, True, False)
+    Restore.run(args, "x86_64", configuration, report=False, unsafe=False)
     extract_mock.extractall.assert_called_once_with(path=args.output)
 
 

--- a/tests/ahriman/application/handlers/test_handler_search.py
+++ b/tests/ahriman/application/handlers/test_handler_search.py
@@ -3,11 +3,11 @@ import dataclasses
 import pytest
 
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.application.handlers import Search
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import InvalidOption
+from ahriman.core.exceptions import OptionError
 from ahriman.models.aur_package import AURPackage
 
 
@@ -41,11 +41,11 @@ def test_run(args: argparse.Namespace, configuration: Configuration, aur_package
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
-    Search.run(args, "x86_64", configuration, True, False)
+    Search.run(args, "x86_64", configuration, report=False, unsafe=False)
     aur_search_mock.assert_called_once_with("ahriman", pacman=pytest.helpers.anyvar(int))
     official_search_mock.assert_called_once_with("ahriman", pacman=pytest.helpers.anyvar(int))
     check_mock.assert_called_once_with(False, False)
-    print_mock.assert_has_calls([mock.call(False), mock.call(False)])
+    print_mock.assert_has_calls([MockCall(False), MockCall(False)])
 
 
 def test_run_empty_exception(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
@@ -60,7 +60,7 @@ def test_run_empty_exception(args: argparse.Namespace, configuration: Configurat
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Search.run(args, "x86_64", configuration, True, False)
+    Search.run(args, "x86_64", configuration, report=False, unsafe=False)
     check_mock.assert_called_once_with(True, True)
 
 
@@ -75,10 +75,10 @@ def test_run_sort(args: argparse.Namespace, configuration: Configuration, aur_pa
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     sort_mock = mocker.patch("ahriman.application.handlers.Search.sort")
 
-    Search.run(args, "x86_64", configuration, True, False)
+    Search.run(args, "x86_64", configuration, report=False, unsafe=False)
     sort_mock.assert_has_calls([
-        mock.call([], "name"), mock.call().__iter__(),
-        mock.call([aur_package_ahriman], "name"), mock.call().__iter__()
+        MockCall([], "name"), MockCall().__iter__(),
+        MockCall([aur_package_ahriman], "name"), MockCall().__iter__()
     ])
 
 
@@ -94,10 +94,10 @@ def test_run_sort_by(args: argparse.Namespace, configuration: Configuration, aur
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     sort_mock = mocker.patch("ahriman.application.handlers.Search.sort")
 
-    Search.run(args, "x86_64", configuration, True, False)
+    Search.run(args, "x86_64", configuration, report=False, unsafe=False)
     sort_mock.assert_has_calls([
-        mock.call([], "field"), mock.call().__iter__(),
-        mock.call([aur_package_ahriman], "field"), mock.call().__iter__()
+        MockCall([], "field"), MockCall().__iter__(),
+        MockCall([aur_package_ahriman], "field"), MockCall().__iter__()
     ])
 
 
@@ -118,7 +118,7 @@ def test_sort_exception(aur_package_ahriman: AURPackage) -> None:
     """
     must raise an exception on unknown sorting field
     """
-    with pytest.raises(InvalidOption):
+    with pytest.raises(OptionError):
         Search.sort([aur_package_ahriman], "random_field")
 
 

--- a/tests/ahriman/application/handlers/test_handler_shell.py
+++ b/tests/ahriman/application/handlers/test_handler_shell.py
@@ -29,7 +29,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_mock = mocker.patch("code.interact")
 
-    Shell.run(args, "x86_64", configuration, True, False)
+    Shell.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with(local=pytest.helpers.anyvar(int))
 
 
@@ -43,6 +43,6 @@ def test_run_verbose(args: argparse.Namespace, configuration: Configuration, moc
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
     application_mock = mocker.patch("code.interact")
 
-    Shell.run(args, "x86_64", configuration, True, False)
+    Shell.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with(local=pytest.helpers.anyvar(int))
     print_mock.assert_called_once_with(verbose=False)

--- a/tests/ahriman/application/handlers/test_handler_sign.py
+++ b/tests/ahriman/application/handlers/test_handler_sign.py
@@ -28,5 +28,5 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     application_mock = mocker.patch("ahriman.application.application.Application.sign")
 
-    Sign.run(args, "x86_64", configuration, True, False)
+    Sign.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with([])

--- a/tests/ahriman/application/handlers/test_handler_status.py
+++ b/tests/ahriman/application/handlers/test_handler_status.py
@@ -1,7 +1,7 @@
 import argparse
 
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.application.handlers import Status
 from ahriman.core.configuration import Configuration
@@ -41,11 +41,11 @@ def test_run(args: argparse.Namespace, configuration: Configuration, package_ahr
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
-    Status.run(args, "x86_64", configuration, True, False)
+    Status.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with()
     packages_mock.assert_called_once_with(None)
     check_mock.assert_called_once_with(False, False)
-    print_mock.assert_has_calls([mock.call(False) for _ in range(3)])
+    print_mock.assert_has_calls([MockCall(False) for _ in range(3)])
 
 
 def test_run_empty_exception(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
@@ -59,7 +59,7 @@ def test_run_empty_exception(args: argparse.Namespace, configuration: Configurat
     mocker.patch("ahriman.core.status.client.Client.get", return_value=[])
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Status.run(args, "x86_64", configuration, True, False)
+    Status.run(args, "x86_64", configuration, report=False, unsafe=False)
     check_mock.assert_called_once_with(True, True)
 
 
@@ -75,8 +75,8 @@ def test_run_verbose(args: argparse.Namespace, configuration: Configuration, pac
                  return_value=[(package_ahriman, BuildStatus(BuildStatusEnum.Success))])
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
-    Status.run(args, "x86_64", configuration, True, False)
-    print_mock.assert_has_calls([mock.call(True) for _ in range(2)])
+    Status.run(args, "x86_64", configuration, report=False, unsafe=False)
+    print_mock.assert_has_calls([MockCall(True) for _ in range(2)])
 
 
 def test_run_with_package_filter(args: argparse.Namespace, configuration: Configuration, package_ahriman: Package,
@@ -90,7 +90,7 @@ def test_run_with_package_filter(args: argparse.Namespace, configuration: Config
     packages_mock = mocker.patch("ahriman.core.status.client.Client.get",
                                  return_value=[(package_ahriman, BuildStatus(BuildStatusEnum.Success))])
 
-    Status.run(args, "x86_64", configuration, True, False)
+    Status.run(args, "x86_64", configuration, report=False, unsafe=False)
     packages_mock.assert_called_once_with(package_ahriman.base)
 
 
@@ -107,8 +107,8 @@ def test_run_by_status(args: argparse.Namespace, configuration: Configuration, p
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
-    Status.run(args, "x86_64", configuration, True, False)
-    print_mock.assert_has_calls([mock.call(False) for _ in range(2)])
+    Status.run(args, "x86_64", configuration, report=False, unsafe=False)
+    print_mock.assert_has_calls([MockCall(False) for _ in range(2)])
 
 
 def test_imply_with_report(args: argparse.Namespace, configuration: Configuration, mocker: MockerFixture) -> None:
@@ -119,7 +119,7 @@ def test_imply_with_report(args: argparse.Namespace, configuration: Configuratio
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     load_mock = mocker.patch("ahriman.core.status.client.Client.load")
 
-    Status.run(args, "x86_64", configuration, True, False)
+    Status.run(args, "x86_64", configuration, report=False, unsafe=False)
     load_mock.assert_called_once_with(configuration)
 
 

--- a/tests/ahriman/application/handlers/test_handler_status_update.py
+++ b/tests/ahriman/application/handlers/test_handler_status_update.py
@@ -33,7 +33,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     update_self_mock = mocker.patch("ahriman.core.status.client.Client.update_self")
 
-    StatusUpdate.run(args, "x86_64", configuration, True, False)
+    StatusUpdate.run(args, "x86_64", configuration, report=False, unsafe=False)
     update_self_mock.assert_called_once_with(args.status)
 
 
@@ -47,7 +47,7 @@ def test_run_packages(args: argparse.Namespace, configuration: Configuration, pa
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     update_mock = mocker.patch("ahriman.core.status.client.Client.update")
 
-    StatusUpdate.run(args, "x86_64", configuration, True, False)
+    StatusUpdate.run(args, "x86_64", configuration, report=False, unsafe=False)
     update_mock.assert_called_once_with(package_ahriman.base, args.status)
 
 
@@ -62,7 +62,7 @@ def test_run_remove(args: argparse.Namespace, configuration: Configuration, pack
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     update_mock = mocker.patch("ahriman.core.status.client.Client.remove")
 
-    StatusUpdate.run(args, "x86_64", configuration, True, False)
+    StatusUpdate.run(args, "x86_64", configuration, report=False, unsafe=False)
     update_mock.assert_called_once_with(package_ahriman.base)
 
 
@@ -74,7 +74,7 @@ def test_imply_with_report(args: argparse.Namespace, configuration: Configuratio
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     load_mock = mocker.patch("ahriman.core.status.client.Client.load")
 
-    StatusUpdate.run(args, "x86_64", configuration, True, False)
+    StatusUpdate.run(args, "x86_64", configuration, report=False, unsafe=False)
     load_mock.assert_called_once_with(configuration)
 
 

--- a/tests/ahriman/application/handlers/test_handler_triggers.py
+++ b/tests/ahriman/application/handlers/test_handler_triggers.py
@@ -31,7 +31,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     application_mock = mocker.patch("ahriman.application.application.Application.on_result")
     on_start_mock = mocker.patch("ahriman.application.application.Application.on_start")
 
-    Triggers.run(args, "x86_64", configuration, True, False)
+    Triggers.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with(Result())
     on_start_mock.assert_called_once_with()
 
@@ -48,6 +48,6 @@ def test_run_trigger(args: argparse.Namespace, configuration: Configuration, pac
     report_mock = mocker.patch("ahriman.core.report.ReportTrigger.on_result")
     upload_mock = mocker.patch("ahriman.core.upload.UploadTrigger.on_result")
 
-    Triggers.run(args, "x86_64", configuration, True, False)
+    Triggers.run(args, "x86_64", configuration, report=False, unsafe=False)
     report_mock.assert_called_once_with(Result(), [package_ahriman])
     upload_mock.assert_not_called()

--- a/tests/ahriman/application/handlers/test_handler_unsafe_commands.py
+++ b/tests/ahriman/application/handlers/test_handler_unsafe_commands.py
@@ -32,7 +32,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
                                  return_value=["command"])
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
-    UnsafeCommands.run(args, "x86_64", configuration, True, False)
+    UnsafeCommands.run(args, "x86_64", configuration, report=False, unsafe=False)
     commands_mock.assert_called_once_with(pytest.helpers.anyvar(int))
     print_mock.assert_called_once_with(verbose=True)
 
@@ -47,7 +47,7 @@ def test_run_check(args: argparse.Namespace, configuration: Configuration, mocke
                                  return_value=["command"])
     check_mock = mocker.patch("ahriman.application.handlers.UnsafeCommands.check_unsafe")
 
-    UnsafeCommands.run(args, "x86_64", configuration, True, False)
+    UnsafeCommands.run(args, "x86_64", configuration, report=False, unsafe=False)
     commands_mock.assert_called_once_with(pytest.helpers.anyvar(int))
     check_mock.assert_called_once_with("clean", ["command"], pytest.helpers.anyvar(int))
 

--- a/tests/ahriman/application/handlers/test_handler_users.py
+++ b/tests/ahriman/application/handlers/test_handler_users.py
@@ -7,7 +7,7 @@ from pytest_mock import MockerFixture
 from ahriman.application.handlers import Users
 from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
-from ahriman.core.exceptions import InitializeException
+from ahriman.core.exceptions import InitializeError
 from ahriman.models.action import Action
 from ahriman.models.user import User
 from ahriman.models.user_access import UserAccess
@@ -47,7 +47,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, database: S
     get_salt_mock = mocker.patch("ahriman.application.handlers.Users.get_salt", return_value="salt")
     update_mock = mocker.patch("ahriman.core.database.SQLite.user_update")
 
-    Users.run(args, "x86_64", configuration, True, False)
+    Users.run(args, "x86_64", configuration, report=False, unsafe=False)
     get_auth_configuration_mock.assert_called_once_with(configuration.include)
     create_configuration_mock.assert_called_once_with(pytest.helpers.anyvar(int), pytest.helpers.anyvar(int),
                                                       pytest.helpers.anyvar(int), args.as_service, args.secure)
@@ -67,7 +67,7 @@ def test_run_list(args: argparse.Namespace, configuration: Configuration, databa
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
     list_mock = mocker.patch("ahriman.core.database.SQLite.user_list", return_value=[user])
 
-    Users.run(args, "x86_64", configuration, True, False)
+    Users.run(args, "x86_64", configuration, report=False, unsafe=False)
     list_mock.assert_called_once_with("user", args.role)
     check_mock.assert_called_once_with(False, False)
 
@@ -84,7 +84,7 @@ def test_run_empty_exception(args: argparse.Namespace, configuration: Configurat
     mocker.patch("ahriman.core.database.SQLite.user_list", return_value=[])
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
-    Users.run(args, "x86_64", configuration, True, False)
+    Users.run(args, "x86_64", configuration, report=False, unsafe=False)
     check_mock.assert_called_once_with(True, True)
 
 
@@ -98,7 +98,7 @@ def test_run_remove(args: argparse.Namespace, configuration: Configuration, data
     mocker.patch("ahriman.core.database.SQLite.load", return_value=database)
     remove_mock = mocker.patch("ahriman.core.database.SQLite.user_remove")
 
-    Users.run(args, "x86_64", configuration, True, False)
+    Users.run(args, "x86_64", configuration, report=False, unsafe=False)
     remove_mock.assert_called_once_with(args.username)
 
 
@@ -176,7 +176,7 @@ def test_configuration_write_not_loaded(configuration: Configuration, mocker: Mo
     configuration.path = None
     mocker.patch("pathlib.Path.open")
 
-    with pytest.raises(InitializeException):
+    with pytest.raises(InitializeError):
         Users.configuration_write(configuration, secure=True)
 
 

--- a/tests/ahriman/application/handlers/test_handler_versions.py
+++ b/tests/ahriman/application/handlers/test_handler_versions.py
@@ -1,7 +1,7 @@
 import argparse
 
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.application.handlers import Versions
 from ahriman.core.configuration import Configuration
@@ -14,9 +14,9 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     application_mock = mocker.patch("ahriman.application.handlers.Versions.package_dependencies")
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
-    Versions.run(args, "x86_64", configuration, True, False)
+    Versions.run(args, "x86_64", configuration, report=False, unsafe=False)
     application_mock.assert_called_once_with("ahriman", ("pacman", "s3", "web"))
-    print_mock.assert_has_calls([mock.call(verbose=False, separator=" "), mock.call(verbose=False, separator=" ")])
+    print_mock.assert_has_calls([MockCall(verbose=False, separator=" "), MockCall(verbose=False, separator=" ")])
 
 
 def test_package_dependencies() -> None:

--- a/tests/ahriman/application/handlers/test_handler_web.py
+++ b/tests/ahriman/application/handlers/test_handler_web.py
@@ -31,7 +31,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, mocker: Moc
     setup_mock = mocker.patch("ahriman.web.web.setup_service")
     run_mock = mocker.patch("ahriman.web.web.run_server")
 
-    Web.run(args, "x86_64", configuration, True, False)
+    Web.run(args, "x86_64", configuration, report=False, unsafe=False)
     setup_mock.assert_called_once_with("x86_64", configuration, pytest.helpers.anyvar(int))
     run_mock.assert_called_once_with(pytest.helpers.anyvar(int))
 

--- a/tests/ahriman/application/test_ahriman.py
+++ b/tests/ahriman/application/test_ahriman.py
@@ -47,12 +47,12 @@ def test_multiple_architectures(parser: argparse.ArgumentParser) -> None:
 
 def test_subparsers_aur_search(parser: argparse.ArgumentParser) -> None:
     """
-    aur-search command must imply architecture list, lock, no-report, quiet and unsafe
+    aur-search command must imply architecture list, lock, report, quiet and unsafe
     """
     args = parser.parse_args(["aur-search", "ahriman"])
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
@@ -99,12 +99,12 @@ def test_subparsers_daemon_option_interval(parser: argparse.ArgumentParser) -> N
 
 def test_subparsers_help(parser: argparse.ArgumentParser) -> None:
     """
-    help command must imply architecture list, lock, no-report, quiet, unsafe and parser
+    help command must imply architecture list, lock, report, quiet, unsafe and parser
     """
     args = parser.parse_args(["help"])
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
     assert args.parser is not None and args.parser()
@@ -120,12 +120,12 @@ def test_subparsers_help_architecture(parser: argparse.ArgumentParser) -> None:
 
 def test_subparsers_help_commands_unsafe(parser: argparse.ArgumentParser) -> None:
     """
-    help-commands-unsafe command must imply architecture list, lock, no-report, quiet, unsafe and parser
+    help-commands-unsafe command must imply architecture list, lock, report, quiet, unsafe and parser
     """
     args = parser.parse_args(["help-commands-unsafe"])
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
     assert args.parser is not None and args.parser()
@@ -141,12 +141,12 @@ def test_subparsers_help_commands_unsafe_architecture(parser: argparse.ArgumentP
 
 def test_subparsers_key_import(parser: argparse.ArgumentParser) -> None:
     """
-    key-import command must imply architecture list, lock and no-report
+    key-import command must imply architecture list, lock and report
     """
     args = parser.parse_args(["key-import", "key"])
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
 
 
 def test_subparsers_key_import_architecture(parser: argparse.ArgumentParser) -> None:
@@ -191,38 +191,38 @@ def test_subparsers_package_remove_architecture(parser: argparse.ArgumentParser)
 
 def test_subparsers_package_status(parser: argparse.ArgumentParser) -> None:
     """
-    package-status command must imply lock, no-report, quiet and unsafe
+    package-status command must imply lock, report, quiet and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "package-status"])
     assert args.architecture == ["x86_64"]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
 
 def test_subparsers_package_status_remove(parser: argparse.ArgumentParser) -> None:
     """
-    package-status-remove command must imply action, lock, no-report, quiet and unsafe
+    package-status-remove command must imply action, lock, report, quiet and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "package-status-remove", "ahriman"])
     assert args.architecture == ["x86_64"]
     assert args.action == Action.Remove
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
 
 def test_subparsers_package_status_update(parser: argparse.ArgumentParser) -> None:
     """
-    package-status-update command must imply action, lock, no-report, quiet and unsafe
+    package-status-update command must imply action, lock, report, quiet and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "package-status-update"])
     assert args.architecture == ["x86_64"]
     assert args.action == Action.Update
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
@@ -239,13 +239,13 @@ def test_subparsers_package_status_update_option_status(parser: argparse.Argumen
 
 def test_subparsers_patch_add(parser: argparse.ArgumentParser) -> None:
     """
-    patch-add command must imply action, architecture list, lock and no-report
+    patch-add command must imply action, architecture list, lock and report
     """
     args = parser.parse_args(["patch-add", "ahriman", "version"])
     assert args.action == Action.Update
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
 
 
 def test_subparsers_patch_add_architecture(parser: argparse.ArgumentParser) -> None:
@@ -258,13 +258,13 @@ def test_subparsers_patch_add_architecture(parser: argparse.ArgumentParser) -> N
 
 def test_subparsers_patch_list(parser: argparse.ArgumentParser) -> None:
     """
-    patch-list command must imply action, architecture list, lock and no-report
+    patch-list command must imply action, architecture list, lock and report
     """
     args = parser.parse_args(["patch-list", "ahriman"])
     assert args.action == Action.List
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
 
 
 def test_subparsers_patch_list_architecture(parser: argparse.ArgumentParser) -> None:
@@ -277,13 +277,13 @@ def test_subparsers_patch_list_architecture(parser: argparse.ArgumentParser) -> 
 
 def test_subparsers_patch_remove(parser: argparse.ArgumentParser) -> None:
     """
-    patch-remove command must imply action, architecture list, lock and no-report
+    patch-remove command must imply action, architecture list, lock and report
     """
     args = parser.parse_args(["patch-remove", "ahriman"])
     assert args.action == Action.Remove
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
 
 
 def test_subparsers_patch_remove_architecture(parser: argparse.ArgumentParser) -> None:
@@ -296,13 +296,13 @@ def test_subparsers_patch_remove_architecture(parser: argparse.ArgumentParser) -
 
 def test_subparsers_patch_set_add(parser: argparse.ArgumentParser) -> None:
     """
-    patch-set-add command must imply action, architecture list, lock, no-report and variable
+    patch-set-add command must imply action, architecture list, lock, report and variable
     """
     args = parser.parse_args(["patch-set-add", "ahriman"])
     assert args.action == Action.Update
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.variable is None
 
 
@@ -332,12 +332,12 @@ def test_subparsers_patch_set_add_option_track(parser: argparse.ArgumentParser) 
 
 def test_subparsers_repo_backup(parser: argparse.ArgumentParser) -> None:
     """
-    repo-backup command must imply architecture list, lock, no-report and unsafe
+    repo-backup command must imply architecture list, lock, report and unsafe
     """
     args = parser.parse_args(["repo-backup", "output.zip"])
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.unsafe
 
 
@@ -351,12 +351,12 @@ def test_subparsers_repo_backup_architecture(parser: argparse.ArgumentParser) ->
 
 def test_subparsers_repo_check(parser: argparse.ArgumentParser) -> None:
     """
-    repo-check command must imply dry-run, no-aur and no-manual
+    repo-check command must imply dry-run, aur and manual
     """
     args = parser.parse_args(["repo-check"])
     assert args.dry_run
-    assert not args.no_aur
-    assert args.no_manual
+    assert args.aur
+    assert not args.manual
 
 
 def test_subparsers_repo_check_architecture(parser: argparse.ArgumentParser) -> None:
@@ -402,12 +402,12 @@ def test_subparsers_repo_clean_architecture(parser: argparse.ArgumentParser) -> 
 
 def test_subparsers_repo_config(parser: argparse.ArgumentParser) -> None:
     """
-    repo-config command must imply lock, no-report, quiet and unsafe
+    repo-config command must imply lock, report, quiet and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "repo-config"])
     assert args.architecture == ["x86_64"]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
@@ -452,12 +452,12 @@ def test_subparsers_repo_report_architecture(parser: argparse.ArgumentParser) ->
 
 def test_subparsers_repo_restore(parser: argparse.ArgumentParser) -> None:
     """
-    repo-restore command must imply architecture list, lock, no-report and unsafe
+    repo-restore command must imply architecture list, lock, report and unsafe
     """
     args = parser.parse_args(["repo-restore", "output.zip"])
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.unsafe
 
 
@@ -471,13 +471,13 @@ def test_subparsers_repo_restore_architecture(parser: argparse.ArgumentParser) -
 
 def test_subparsers_repo_setup(parser: argparse.ArgumentParser) -> None:
     """
-    repo-setup command must imply lock, no-report, quiet and unsafe
+    repo-setup command must imply lock, report, quiet and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "repo-setup", "--packager", "John Doe <john@doe.com>",
                               "--repository", "aur-clone"])
     assert args.architecture == ["x86_64"]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
@@ -516,13 +516,13 @@ def test_subparsers_repo_sign_architecture(parser: argparse.ArgumentParser) -> N
 
 def test_subparsers_repo_status_update(parser: argparse.ArgumentParser) -> None:
     """
-    re[p-status-update command must imply action, lock, no-report, package, quiet and unsafe
+    re[p-status-update command must imply action, lock, report, package, quiet and unsafe
     """
     args = parser.parse_args(["-a", "x86_64", "package-status-update"])
     assert args.architecture == ["x86_64"]
     assert args.action == Action.Update
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert not args.package
     assert args.quiet
     assert args.unsafe
@@ -590,22 +590,22 @@ def test_subparsers_repo_update_option_refresh(parser: argparse.ArgumentParser) 
 
 def test_subparsers_shell(parser: argparse.ArgumentParser) -> None:
     """
-    shell command must imply lock and no-report
+    shell command must imply lock and report
     """
     args = parser.parse_args(["shell"])
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
 
 
 def test_subparsers_user_add(parser: argparse.ArgumentParser) -> None:
     """
-    user-add command must imply action, architecture, lock, no-report, quiet and unsafe
+    user-add command must imply action, architecture, lock, report, quiet and unsafe
     """
     args = parser.parse_args(["user-add", "username"])
     assert args.action == Action.Update
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
@@ -630,13 +630,13 @@ def test_subparsers_user_add_option_role(parser: argparse.ArgumentParser) -> Non
 
 def test_subparsers_user_list(parser: argparse.ArgumentParser) -> None:
     """
-    user-list command must imply action, architecture, lock, no-report, password, quiet and unsafe
+    user-list command must imply action, architecture, lock, report, password, quiet and unsafe
     """
     args = parser.parse_args(["user-list"])
     assert args.action == Action.List
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.password is not None
     assert args.quiet
     assert args.unsafe
@@ -660,13 +660,13 @@ def test_subparsers_user_list_option_role(parser: argparse.ArgumentParser) -> No
 
 def test_subparsers_user_remove(parser: argparse.ArgumentParser) -> None:
     """
-    user-remove command must imply action, architecture, lock, no-report, password, quiet, role and unsafe
+    user-remove command must imply action, architecture, lock, report, password, quiet, role and unsafe
     """
     args = parser.parse_args(["user-remove", "username"])
     assert args.action == Action.Remove
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.password is not None
     assert args.quiet
     assert args.unsafe
@@ -682,12 +682,12 @@ def test_subparsers_user_remove_architecture(parser: argparse.ArgumentParser) ->
 
 def test_subparsers_version(parser: argparse.ArgumentParser) -> None:
     """
-    version command must imply architecture, lock, no-report, quiet and unsafe
+    version command must imply architecture, lock, report, quiet and unsafe
     """
     args = parser.parse_args(["version"])
     assert args.architecture == [""]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.quiet
     assert args.unsafe
 
@@ -702,12 +702,12 @@ def test_subparsers_version_architecture(parser: argparse.ArgumentParser) -> Non
 
 def test_subparsers_web(parser: argparse.ArgumentParser) -> None:
     """
-    web command must imply lock, no_report and parser
+    web command must imply lock, report and parser
     """
     args = parser.parse_args(["-a", "x86_64", "web"])
     assert args.architecture == ["x86_64"]
     assert args.lock is None
-    assert args.no_report
+    assert not args.report
     assert args.parser is not None and args.parser()
 
 

--- a/tests/ahriman/core/alpm/remote/test_aur.py
+++ b/tests/ahriman/core/alpm/remote/test_aur.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.remote import AUR
-from ahriman.core.exceptions import InvalidPackageInfo
+from ahriman.core.exceptions import PackageInfoError, UnknownPackageError
 from ahriman.models.aur_package import AURPackage
 
 
@@ -38,7 +38,7 @@ def test_parse_response_error(resource_path_root: Path) -> None:
     must raise exception on invalid response
     """
     response = (resource_path_root / "models" / "aur_error").read_text()
-    with pytest.raises(InvalidPackageInfo, match="Incorrect request type specified."):
+    with pytest.raises(PackageInfoError, match="Incorrect request type specified."):
         AUR.parse_response(json.loads(response))
 
 
@@ -46,7 +46,7 @@ def test_parse_response_unknown_error() -> None:
     """
     must raise exception on invalid response with empty error message
     """
-    with pytest.raises(InvalidPackageInfo, match="Unknown API error"):
+    with pytest.raises(PackageInfoError, match="Unknown API error"):
         AUR.parse_response({"type": "error"})
 
 
@@ -140,6 +140,16 @@ def test_package_info(aur: AUR, aur_package_ahriman: AURPackage, pacman: Pacman,
     request_mock = mocker.patch("ahriman.core.alpm.remote.AUR.make_request", return_value=[aur_package_ahriman])
     assert aur.package_info(aur_package_ahriman.name, pacman=pacman) == aur_package_ahriman
     request_mock.assert_called_once_with("info", aur_package_ahriman.name)
+
+
+def test_package_info_not_found(aur: AUR, aur_package_ahriman: AURPackage, pacman: Pacman,
+                                mocker: MockerFixture) -> None:
+    """
+    must raise UnknownPackage exception in case if no package was found
+    """
+    mocker.patch("ahriman.core.alpm.remote.AUR.make_request", return_value=[])
+    with pytest.raises(UnknownPackageError, match=aur_package_ahriman.name):
+        assert aur.package_info(aur_package_ahriman.name, pacman=pacman)
 
 
 def test_package_search(aur: AUR, aur_package_ahriman: AURPackage, pacman: Pacman, mocker: MockerFixture) -> None:

--- a/tests/ahriman/core/alpm/remote/test_official_syncdb.py
+++ b/tests/ahriman/core/alpm/remote/test_official_syncdb.py
@@ -1,12 +1,15 @@
+import pytest
+
 from pytest_mock import MockerFixture
 
 from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.remote import OfficialSyncdb
+from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.aur_package import AURPackage
 
 
-def test_package_info(official_syncdb: OfficialSyncdb, aur_package_akonadi: AURPackage,
-                      pacman: Pacman, mocker: MockerFixture) -> None:
+def test_package_info(official_syncdb: OfficialSyncdb, aur_package_akonadi: AURPackage, pacman: Pacman,
+                      mocker: MockerFixture) -> None:
     """
     must return package info from the database
     """
@@ -16,3 +19,13 @@ def test_package_info(official_syncdb: OfficialSyncdb, aur_package_akonadi: AURP
     package = official_syncdb.package_info(aur_package_akonadi.name, pacman=pacman)
     get_mock.assert_called_once_with(aur_package_akonadi.name)
     assert package == aur_package_akonadi
+
+
+def test_package_info_not_found(official_syncdb: OfficialSyncdb, aur_package_akonadi: AURPackage, pacman: Pacman,
+                                mocker: MockerFixture) -> None:
+    """
+    must raise UnknownPackage exception in case if no package was found
+    """
+    mocker.patch("ahriman.core.alpm.pacman.Pacman.package_get", return_value=[])
+    with pytest.raises(UnknownPackageError, match=aur_package_akonadi.name):
+        assert official_syncdb.package_info(aur_package_akonadi.name, pacman=pacman)

--- a/tests/ahriman/core/alpm/remote/test_remote.py
+++ b/tests/ahriman/core/alpm/remote/test_remote.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.alpm.pacman import Pacman
 from ahriman.core.alpm.remote import Remote
@@ -25,7 +25,7 @@ def test_multisearch(aur_package_ahriman: AURPackage, pacman: Pacman, mocker: Mo
     search_mock = mocker.patch("ahriman.core.alpm.remote.Remote.search", return_value=[aur_package_ahriman])
 
     assert Remote.multisearch(*terms, pacman=pacman) == [aur_package_ahriman]
-    search_mock.assert_has_calls([mock.call("ahriman", pacman=pacman), mock.call("cool", pacman=pacman)])
+    search_mock.assert_has_calls([MockCall("ahriman", pacman=pacman), MockCall("cool", pacman=pacman)])
 
 
 def test_multisearch_empty(pacman: Pacman, mocker: MockerFixture) -> None:

--- a/tests/ahriman/core/auth/test_oauth.py
+++ b/tests/ahriman/core/auth/test_oauth.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ahriman.core.auth import OAuth
-from ahriman.core.exceptions import InvalidOption
+from ahriman.core.exceptions import OptionError
 
 
 def test_auth_control(oauth: OAuth) -> None:
@@ -28,7 +28,7 @@ def test_get_provider_not_a_type() -> None:
     """
     must raise an exception if attribute is not a type
     """
-    with pytest.raises(InvalidOption):
+    with pytest.raises(OptionError):
         OAuth.get_provider("__version__")
 
 
@@ -36,9 +36,9 @@ def test_get_provider_invalid_type() -> None:
     """
     must raise an exception if attribute is not an OAuth2 client
     """
-    with pytest.raises(InvalidOption):
+    with pytest.raises(OptionError):
         OAuth.get_provider("User")
-    with pytest.raises(InvalidOption):
+    with pytest.raises(OptionError):
         OAuth.get_provider("OAuth1Client")
 
 

--- a/tests/ahriman/core/build_tools/test_sources.py
+++ b/tests/ahriman/core/build_tools/test_sources.py
@@ -2,7 +2,7 @@ import pytest
 
 from pathlib import Path
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.build_tools.sources import Sources
 from ahriman.models.package import Package
@@ -55,12 +55,12 @@ def test_fetch_existing(remote_source: RemoteSource, mocker: MockerFixture) -> N
     local = Path("local")
     Sources.fetch(local, remote_source)
     check_output_mock.assert_has_calls([
-        mock.call("git", "fetch", "origin", remote_source.branch,
-                  exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "checkout", "--force", remote_source.branch,
-                  exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "reset", "--hard", f"origin/{remote_source.branch}",
-                  exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
+        MockCall("git", "fetch", "origin", remote_source.branch,
+                 exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
+        MockCall("git", "checkout", "--force", remote_source.branch,
+                 exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
+        MockCall("git", "reset", "--hard", f"origin/{remote_source.branch}",
+                 exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
     ])
     move_mock.assert_called_once_with(local.resolve(), local)
 
@@ -76,12 +76,12 @@ def test_fetch_new(remote_source: RemoteSource, mocker: MockerFixture) -> None:
     local = Path("local")
     Sources.fetch(local, remote_source)
     check_output_mock.assert_has_calls([
-        mock.call("git", "clone", "--branch", remote_source.branch, "--single-branch",
-                  remote_source.git_url, str(local), exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "checkout", "--force", remote_source.branch,
-                  exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "reset", "--hard", f"origin/{remote_source.branch}",
-                  exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
+        MockCall("git", "clone", "--branch", remote_source.branch, "--single-branch",
+                 remote_source.git_url, str(local), exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
+        MockCall("git", "checkout", "--force", remote_source.branch,
+                 exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
+        MockCall("git", "reset", "--hard", f"origin/{remote_source.branch}",
+                 exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
     ])
     move_mock.assert_called_once_with(local.resolve(), local)
 
@@ -97,10 +97,10 @@ def test_fetch_new_without_remote(mocker: MockerFixture) -> None:
     local = Path("local")
     Sources.fetch(local, None)
     check_output_mock.assert_has_calls([
-        mock.call("git", "checkout", "--force", Sources.DEFAULT_BRANCH,
-                  exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
-        mock.call("git", "reset", "--hard", f"origin/{Sources.DEFAULT_BRANCH}",
-                  exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
+        MockCall("git", "checkout", "--force", Sources.DEFAULT_BRANCH,
+                 exception=None, cwd=local, logger=pytest.helpers.anyvar(int)),
+        MockCall("git", "reset", "--hard", f"origin/{Sources.DEFAULT_BRANCH}",
+                 exception=None, cwd=local, logger=pytest.helpers.anyvar(int))
     ])
     move_mock.assert_called_once_with(local.resolve(), local)
 
@@ -237,7 +237,7 @@ def test_add(sources: Sources, mocker: MockerFixture) -> None:
 
     local = Path("local")
     sources.add(local, "pattern1", "pattern2")
-    glob_mock.assert_has_calls([mock.call("pattern1"), mock.call("pattern2")])
+    glob_mock.assert_has_calls([MockCall("pattern1"), MockCall("pattern2")])
     check_output_mock.assert_called_once_with(
         "git", "add", "--intent-to-add", "1", "2", "1", "2",
         exception=None, cwd=local, logger=pytest.helpers.anyvar(int))

--- a/tests/ahriman/core/database/data/test_package_statuses.py
+++ b/tests/ahriman/core/database/data/test_package_statuses.py
@@ -2,7 +2,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 from sqlite3 import Connection
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.database.data import migrate_package_statuses
 from ahriman.models.package import Package
@@ -22,11 +22,11 @@ def test_migrate_package_statuses(connection: Connection, package_ahriman: Packa
 
     migrate_package_statuses(connection, repository_paths)
     connection.execute.assert_has_calls([
-        mock.call(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
-        mock.call(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
+        MockCall(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
+        MockCall(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
     ])
     connection.executemany.assert_has_calls([
-        mock.call(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
+        MockCall(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
     ])
 
 

--- a/tests/ahriman/core/database/data/test_users.py
+++ b/tests/ahriman/core/database/data/test_users.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sqlite3 import Connection
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.database.data import migrate_users_data
@@ -16,6 +16,6 @@ def test_migrate_users_data(connection: Connection, configuration: Configuration
 
     migrate_users_data(connection, configuration)
     connection.execute.assert_has_calls([
-        mock.call(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
-        mock.call(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
+        MockCall(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
+        MockCall(pytest.helpers.anyvar(str, strict=True), pytest.helpers.anyvar(int)),
     ])

--- a/tests/ahriman/core/database/migrations/test_migrations_init.py
+++ b/tests/ahriman/core/database/migrations/test_migrations_init.py
@@ -2,8 +2,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 from sqlite3 import Connection
-from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call as MockCall
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.database.migrations import Migrations
@@ -52,10 +51,10 @@ def test_run(migrations: Migrations, mocker: MockerFixture) -> None:
     migrations.run()
     validate_mock.assert_called_once_with()
     cursor.execute.assert_has_calls([
-        mock.call("begin exclusive"),
-        mock.call("select 1"),
-        mock.call("pragma user_version = 1"),
-        mock.call("commit"),
+        MockCall("begin exclusive"),
+        MockCall("select 1"),
+        MockCall("pragma user_version = 1"),
+        MockCall("commit"),
     ])
     cursor.close.assert_called_once_with()
     migrate_data_mock.assert_called_once_with(
@@ -77,8 +76,8 @@ def test_run_migration_exception(migrations: Migrations, mocker: MockerFixture) 
     with pytest.raises(Exception):
         migrations.run()
     cursor.execute.assert_has_calls([
-        mock.call("begin exclusive"),
-        mock.call("rollback"),
+        MockCall("begin exclusive"),
+        MockCall("rollback"),
     ])
     cursor.close.assert_called_once_with()
 

--- a/tests/ahriman/core/database/operations/test_package_operations.py
+++ b/tests/ahriman/core/database/operations/test_package_operations.py
@@ -2,7 +2,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 from sqlite3 import Connection
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.database import SQLite
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
@@ -17,8 +17,8 @@ def test_package_remove_package_base(database: SQLite, connection: Connection) -
     """
     database._package_remove_package_base(connection, "package")
     connection.execute.assert_has_calls([
-        mock.call(pytest.helpers.anyvar(str, strict=True), {"package_base": "package"}),
-        mock.call(pytest.helpers.anyvar(str, strict=True), {"package_base": "package"}),
+        MockCall(pytest.helpers.anyvar(str, strict=True), {"package_base": "package"}),
+        MockCall(pytest.helpers.anyvar(str, strict=True), {"package_base": "package"}),
     ])
 
 

--- a/tests/ahriman/core/gitremote/test_remote_pull.py
+++ b/tests/ahriman/core/gitremote/test_remote_pull.py
@@ -2,10 +2,10 @@ import pytest
 
 from pathlib import Path
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import GitRemoteFailed
+from ahriman.core.exceptions import GitRemoteError
 from ahriman.core.gitremote.remote_pull import RemotePull
 
 
@@ -39,12 +39,12 @@ def test_repo_copy(configuration: Configuration, mocker: MockerFixture) -> None:
 
     runner.repo_copy(Path("local"))
     copytree_mock.assert_has_calls([
-        mock.call(Path("local") / "package1", configuration.repository_paths.cache_for("package1"), dirs_exist_ok=True),
-        mock.call(Path("local") / "package3", configuration.repository_paths.cache_for("package3"), dirs_exist_ok=True),
+        MockCall(Path("local") / "package1", configuration.repository_paths.cache_for("package1"), dirs_exist_ok=True),
+        MockCall(Path("local") / "package3", configuration.repository_paths.cache_for("package3"), dirs_exist_ok=True),
     ])
     init_mock.assert_has_calls([
-        mock.call(configuration.repository_paths.cache_for("package1")),
-        mock.call(configuration.repository_paths.cache_for("package3")),
+        MockCall(configuration.repository_paths.cache_for("package1")),
+        MockCall(configuration.repository_paths.cache_for("package3")),
     ])
 
 
@@ -66,5 +66,5 @@ def test_run_failed(configuration: Configuration, mocker: MockerFixture) -> None
     mocker.patch("ahriman.core.gitremote.remote_pull.RemotePull.repo_clone", side_effect=Exception())
     runner = RemotePull(configuration, "gitremote")
 
-    with pytest.raises(GitRemoteFailed):
+    with pytest.raises(GitRemoteError):
         runner.run()

--- a/tests/ahriman/core/gitremote/test_remote_push.py
+++ b/tests/ahriman/core/gitremote/test_remote_push.py
@@ -2,10 +2,10 @@ import pytest
 
 from pathlib import Path
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import GitRemoteFailed
+from ahriman.core.exceptions import GitRemoteError
 from ahriman.core.gitremote.remote_push import RemotePush
 from ahriman.models.package import Package
 from ahriman.models.result import Result
@@ -22,9 +22,9 @@ def test_package_update(package_ahriman: Package, mocker: MockerFixture) -> None
     local = Path("local")
     RemotePush.package_update(package_ahriman, local)
     rmtree_mock.assert_has_calls([
-        mock.call(local / package_ahriman.base, ignore_errors=True),
-        mock.call(pytest.helpers.anyvar(int), onerror=pytest.helpers.anyvar(int)),  # removal of the TemporaryDirectory
-        mock.call(local / package_ahriman.base / ".git", ignore_errors=True),
+        MockCall(local / package_ahriman.base, ignore_errors=True),
+        MockCall(pytest.helpers.anyvar(int), onerror=pytest.helpers.anyvar(int)),  # removal of the TemporaryDirectory
+        MockCall(local / package_ahriman.base / ".git", ignore_errors=True),
     ])
     fetch_mock.assert_called_once_with(pytest.helpers.anyvar(int), package_ahriman.remote)
     copytree_mock.assert_called_once_with(pytest.helpers.anyvar(int), local / package_ahriman.base)
@@ -63,5 +63,5 @@ def test_run_failed(configuration: Configuration, result: Result, mocker: Mocker
     mocker.patch("ahriman.core.build_tools.sources.Sources.fetch", side_effect=Exception())
     runner = RemotePush(configuration, "gitremote")
 
-    with pytest.raises(GitRemoteFailed):
+    with pytest.raises(GitRemoteError):
         runner.run(result)

--- a/tests/ahriman/core/report/test_console.py
+++ b/tests/ahriman/core/report/test_console.py
@@ -1,5 +1,5 @@
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.report.console import Console
@@ -17,4 +17,4 @@ def test_generate(configuration: Configuration, result: Result, package_python_s
     report = Console("x86_64", configuration, "console")
 
     report.generate([], result)
-    print_mock.assert_has_calls([mock.call(verbose=True), mock.call(verbose=True)])
+    print_mock.assert_has_calls([MockCall(verbose=True), MockCall(verbose=True)])

--- a/tests/ahriman/core/report/test_report.py
+++ b/tests/ahriman/core/report/test_report.py
@@ -3,7 +3,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import ReportFailed
+from ahriman.core.exceptions import ReportError
 from ahriman.core.report.report import Report
 from ahriman.models.report_settings import ReportSettings
 from ahriman.models.result import Result
@@ -14,7 +14,7 @@ def test_report_failure(configuration: Configuration, mocker: MockerFixture) -> 
     must raise ReportFailed on errors
     """
     mocker.patch("ahriman.core.report.html.HTML.generate", side_effect=Exception())
-    with pytest.raises(ReportFailed):
+    with pytest.raises(ReportError):
         Report.load("x86_64", configuration, "html").run(Result(), [])
 
 

--- a/tests/ahriman/core/report/test_telegram.py
+++ b/tests/ahriman/core/report/test_telegram.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.report.telegram import Telegram
@@ -81,7 +81,7 @@ def test_generate_big_text(configuration: Configuration, package_ahriman: Packag
     report = Telegram("x86_64", configuration, "telegram")
     report.generate([package_ahriman], result)
     send_mock.assert_has_calls([
-        mock.call(pytest.helpers.anyvar(str, strict=True)), mock.call(pytest.helpers.anyvar(str, strict=True))
+        MockCall(pytest.helpers.anyvar(str, strict=True)), MockCall(pytest.helpers.anyvar(str, strict=True))
     ])
 
 
@@ -96,9 +96,9 @@ def test_generate_very_big_text(configuration: Configuration, package_ahriman: P
     report = Telegram("x86_64", configuration, "telegram")
     report.generate([package_ahriman], result)
     send_mock.assert_has_calls([
-        mock.call(pytest.helpers.anyvar(str, strict=True)),
-        mock.call(pytest.helpers.anyvar(str, strict=True)),
-        mock.call(pytest.helpers.anyvar(str, strict=True)),
+        MockCall(pytest.helpers.anyvar(str, strict=True)),
+        MockCall(pytest.helpers.anyvar(str, strict=True)),
+        MockCall(pytest.helpers.anyvar(str, strict=True)),
     ])
 
 

--- a/tests/ahriman/core/repository/conftest.py
+++ b/tests/ahriman/core/repository/conftest.py
@@ -24,7 +24,7 @@ def cleaner(configuration: Configuration, database: SQLite, mocker: MockerFixtur
         Cleaner: cleaner test instance
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
-    return Cleaner("x86_64", configuration, database, no_report=True, unsafe=False)
+    return Cleaner("x86_64", configuration, database, report=False, unsafe=False)
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def executor(configuration: Configuration, database: SQLite, mocker: MockerFixtu
     mocker.patch("ahriman.core.repository.cleaner.Cleaner.clear_packages")
     mocker.patch("ahriman.core.repository.cleaner.Cleaner.clear_queue")
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
-    return Executor("x86_64", configuration, database, no_report=True, unsafe=False)
+    return Executor("x86_64", configuration, database, report=False, unsafe=False)
 
 
 @pytest.fixture
@@ -62,7 +62,7 @@ def repository(configuration: Configuration, database: SQLite, mocker: MockerFix
         Repository: repository test instance
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
-    return Repository("x86_64", configuration, database, no_report=True, unsafe=False)
+    return Repository("x86_64", configuration, database, report=False, unsafe=False)
 
 
 @pytest.fixture
@@ -83,4 +83,4 @@ def update_handler(configuration: Configuration, database: SQLite, mocker: Mocke
     mocker.patch("ahriman.core.repository.cleaner.Cleaner.clear_packages")
     mocker.patch("ahriman.core.repository.cleaner.Cleaner.clear_queue")
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
-    return UpdateHandler("x86_64", configuration, database, no_report=True, unsafe=False)
+    return UpdateHandler("x86_64", configuration, database, report=False, unsafe=False)

--- a/tests/ahriman/core/repository/test_cleaner.py
+++ b/tests/ahriman/core/repository/test_cleaner.py
@@ -3,7 +3,7 @@ import shutil
 
 from pathlib import Path
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.repository.cleaner import Cleaner
 
@@ -24,9 +24,9 @@ def _mock_clear_check() -> None:
     mocker helper for clear tests
     """
     shutil.rmtree.assert_has_calls([
-        mock.call(Path("a")),
-        mock.call(Path("b")),
-        mock.call(Path("c"))
+        MockCall(Path("a")),
+        MockCall(Path("b")),
+        MockCall(Path("c"))
     ])
 
 
@@ -65,7 +65,16 @@ def test_clear_packages(cleaner: Cleaner, mocker: MockerFixture) -> None:
     mocker.patch("pathlib.Path.unlink")
 
     cleaner.clear_packages()
-    Path.unlink.assert_has_calls([mock.call(), mock.call(), mock.call()])
+    Path.unlink.assert_has_calls([MockCall(), MockCall(), MockCall()])
+
+
+def test_clear_pacman(cleaner: Cleaner, mocker: MockerFixture) -> None:
+    """
+    must delete built packages
+    """
+    _mock_clear(mocker)
+    cleaner.clear_pacman()
+    _mock_clear_check()
 
 
 def test_clear_queue(cleaner: Cleaner, mocker: MockerFixture) -> None:

--- a/tests/ahriman/core/repository/test_executor.py
+++ b/tests/ahriman/core/repository/test_executor.py
@@ -2,7 +2,7 @@ import pytest
 
 from pathlib import Path
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.repository.executor import Executor
 from ahriman.models.package import Package
@@ -88,7 +88,7 @@ def test_process_remove_base_multiple(executor: Executor, package_python_schedul
     executor.process_remove([package_python_schedule.base])
     # must remove via alpm wrapper
     repo_remove_mock.assert_has_calls([
-        mock.call(package, props.filepath)
+        MockCall(package, props.filepath)
         for package, props in package_python_schedule.packages.items()
     ], any_order=True)
     # must update status
@@ -186,7 +186,7 @@ def test_process_update_group(executor: Executor, package_python_schedule: Packa
 
     executor.process_update([package.filepath for package in package_python_schedule.packages.values()])
     repo_add_mock.assert_has_calls([
-        mock.call(executor.paths.repository / package.filepath)
+        MockCall(executor.paths.repository / package.filepath)
         for package in package_python_schedule.packages.values()
     ], any_order=True)
     status_client_mock.assert_called_once_with(package_python_schedule)
@@ -208,8 +208,8 @@ def test_process_update_unsafe(executor: Executor, package_ahriman: Package, moc
 
     executor.process_update([Path(path)])
     move_mock.assert_has_calls([
-        mock.call(executor.paths.packages / path, executor.paths.packages / safe_path),
-        mock.call(executor.paths.packages / safe_path, executor.paths.repository / safe_path)
+        MockCall(executor.paths.packages / path, executor.paths.packages / safe_path),
+        MockCall(executor.paths.packages / safe_path, executor.paths.repository / safe_path)
     ])
     repo_add_mock.assert_called_once_with(executor.paths.repository / safe_path)
 

--- a/tests/ahriman/core/repository/test_repository_properties.py
+++ b/tests/ahriman/core/repository/test_repository_properties.py
@@ -2,7 +2,7 @@ from pytest_mock import MockerFixture
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
-from ahriman.core.exceptions import UnsafeRun
+from ahriman.core.exceptions import UnsafeRunError
 from ahriman.core.repository.repository_properties import RepositoryProperties
 from ahriman.core.status.web_client import WebClient
 
@@ -13,7 +13,7 @@ def test_create_tree_on_load(configuration: Configuration, database: SQLite, moc
     """
     mocker.patch("ahriman.core.repository.repository_properties.check_user")
     tree_create_mock = mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
-    RepositoryProperties("x86_64", configuration, database, True, False)
+    RepositoryProperties("x86_64", configuration, database, report=False, unsafe=False)
 
     tree_create_mock.assert_called_once_with()
 
@@ -22,9 +22,9 @@ def test_create_tree_on_load_unsafe(configuration: Configuration, database: SQLi
     """
     must not create tree on load in case if user differs from the root owner
     """
-    mocker.patch("ahriman.core.repository.repository_properties.check_user", side_effect=UnsafeRun(0, 1))
+    mocker.patch("ahriman.core.repository.repository_properties.check_user", side_effect=UnsafeRunError(0, 1))
     tree_create_mock = mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
-    RepositoryProperties("x86_64", configuration, database, True, False)
+    RepositoryProperties("x86_64", configuration, database, report=False, unsafe=False)
 
     tree_create_mock.assert_not_called()
 
@@ -35,7 +35,7 @@ def test_create_dummy_report_client(configuration: Configuration, database: SQLi
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     load_mock = mocker.patch("ahriman.core.status.client.Client.load")
-    properties = RepositoryProperties("x86_64", configuration, database, True, False)
+    properties = RepositoryProperties("x86_64", configuration, database, report=False, unsafe=False)
 
     load_mock.assert_not_called()
     assert not isinstance(properties.reporter, WebClient)
@@ -47,6 +47,6 @@ def test_create_full_report_client(configuration: Configuration, database: SQLit
     """
     mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_create")
     load_mock = mocker.patch("ahriman.core.status.client.Client.load")
-    RepositoryProperties("x86_64", configuration, database, False, False)
+    RepositoryProperties("x86_64", configuration, database, report=True, unsafe=True)
 
     load_mock.assert_called_once_with(configuration)

--- a/tests/ahriman/core/repository/test_update_handler.py
+++ b/tests/ahriman/core/repository/test_update_handler.py
@@ -26,7 +26,7 @@ def test_updates_aur(update_handler: UpdateHandler, package_ahriman: Package,
     mocker.patch("ahriman.models.package.Package.from_aur", return_value=package_ahriman)
     status_client_mock = mocker.patch("ahriman.core.status.client.Client.set_pending")
 
-    assert update_handler.updates_aur([], False) == [package_ahriman]
+    assert update_handler.updates_aur([], vcs=True) == [package_ahriman]
     status_client_mock.assert_called_once_with(package_ahriman.base)
 
 
@@ -41,7 +41,7 @@ def test_updates_aur_official(update_handler: UpdateHandler, package_ahriman: Pa
     mocker.patch("ahriman.models.package.Package.from_official", return_value=package_ahriman)
     status_client_mock = mocker.patch("ahriman.core.status.client.Client.set_pending")
 
-    assert update_handler.updates_aur([], False) == [package_ahriman]
+    assert update_handler.updates_aur([], vcs=True) == [package_ahriman]
     status_client_mock.assert_called_once_with(package_ahriman.base)
 
 
@@ -54,7 +54,7 @@ def test_updates_aur_failed(update_handler: UpdateHandler, package_ahriman: Pack
     mocker.patch("ahriman.models.package.Package.from_aur", side_effect=Exception())
     status_client_mock = mocker.patch("ahriman.core.status.client.Client.set_failed")
 
-    update_handler.updates_aur([], False)
+    update_handler.updates_aur([], vcs=True)
     status_client_mock.assert_called_once_with(package_ahriman.base)
 
 
@@ -68,7 +68,7 @@ def test_updates_aur_filter(update_handler: UpdateHandler, package_ahriman: Pack
     mocker.patch("ahriman.models.package.Package.is_outdated", return_value=True)
     package_load_mock = mocker.patch("ahriman.models.package.Package.from_aur", return_value=package_ahriman)
 
-    assert update_handler.updates_aur([package_ahriman.base], False) == [package_ahriman]
+    assert update_handler.updates_aur([package_ahriman.base], vcs=True) == [package_ahriman]
     package_load_mock.assert_called_once_with(package_ahriman.base, update_handler.pacman)
 
 
@@ -81,7 +81,7 @@ def test_updates_aur_ignore(update_handler: UpdateHandler, package_ahriman: Pack
     mocker.patch("ahriman.core.repository.update_handler.UpdateHandler.packages", return_value=[package_ahriman])
     package_load_mock = mocker.patch("ahriman.models.package.Package.from_aur")
 
-    update_handler.updates_aur([], False)
+    update_handler.updates_aur([], vcs=True)
     package_load_mock.assert_not_called()
 
 
@@ -94,7 +94,7 @@ def test_updates_aur_ignore_vcs(update_handler: UpdateHandler, package_ahriman: 
     mocker.patch("ahriman.models.package.Package.is_vcs", return_value=True)
     package_is_outdated_mock = mocker.patch("ahriman.models.package.Package.is_outdated")
 
-    update_handler.updates_aur([], True)
+    update_handler.updates_aur([], vcs=False)
     package_is_outdated_mock.assert_not_called()
 
 

--- a/tests/ahriman/core/status/test_watcher.py
+++ b/tests/ahriman/core/status/test_watcher.py
@@ -4,7 +4,7 @@ from pytest_mock import MockerFixture
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
-from ahriman.core.exceptions import UnknownPackage
+from ahriman.core.exceptions import UnknownPackageError
 from ahriman.core.status.watcher import Watcher
 from ahriman.core.status.web_client import WebClient
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
@@ -39,7 +39,7 @@ def test_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
     """
     must fail on unknown package
     """
-    with pytest.raises(UnknownPackage):
+    with pytest.raises(UnknownPackageError):
         watcher.get(package_ahriman.base)
 
 
@@ -124,7 +124,7 @@ def test_update_unknown(watcher: Watcher, package_ahriman: Package) -> None:
     """
     must fail on unknown package status update only
     """
-    with pytest.raises(UnknownPackage):
+    with pytest.raises(UnknownPackageError):
         watcher.update(package_ahriman.base, BuildStatusEnum.Unknown, None)
 
 

--- a/tests/ahriman/core/test_configuration.py
+++ b/tests/ahriman/core/test_configuration.py
@@ -4,10 +4,10 @@ import pytest
 
 from pathlib import Path
 from pytest_mock import MockerFixture
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import InitializeException
+from ahriman.core.exceptions import InitializeError
 from ahriman.models.repository_paths import RepositoryPaths
 
 
@@ -62,7 +62,7 @@ def test_check_loaded_path(configuration: Configuration) -> None:
     must raise exception if path is none
     """
     configuration.path = None
-    with pytest.raises(InitializeException):
+    with pytest.raises(InitializeError):
         configuration.check_loaded()
 
 
@@ -71,7 +71,7 @@ def test_check_loaded_architecture(configuration: Configuration) -> None:
     must raise exception if architecture is none
     """
     configuration.architecture = None
-    with pytest.raises(InitializeException):
+    with pytest.raises(InitializeError):
         configuration.check_loaded()
 
 
@@ -312,7 +312,7 @@ def test_reload_clear(configuration: Configuration, mocker: MockerFixture) -> No
     sections = configuration.sections()
 
     configuration.reload()
-    clear_mock.assert_has_calls([mock.call(section) for section in sections])
+    clear_mock.assert_has_calls([MockCall(section) for section in sections])
 
 
 def test_reload_no_architecture(configuration: Configuration) -> None:
@@ -320,7 +320,7 @@ def test_reload_no_architecture(configuration: Configuration) -> None:
     must raise exception on reload if no architecture set
     """
     configuration.architecture = None
-    with pytest.raises(InitializeException):
+    with pytest.raises(InitializeError):
         configuration.reload()
 
 
@@ -329,7 +329,7 @@ def test_reload_no_path(configuration: Configuration) -> None:
     must raise exception on reload if no path set
     """
     configuration.path = None
-    with pytest.raises(InitializeException):
+    with pytest.raises(InitializeError):
         configuration.reload()
 
 

--- a/tests/ahriman/core/triggers/test_trigger_loader.py
+++ b/tests/ahriman/core/triggers/test_trigger_loader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pytest_mock import MockerFixture
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import InvalidExtension
+from ahriman.core.exceptions import ExtensionError
 from ahriman.core.triggers import TriggerLoader
 from ahriman.models.package import Package
 from ahriman.models.result import Result
@@ -22,7 +22,7 @@ def test_load_trigger_package_invalid_import(trigger_loader: TriggerLoader, mock
     must raise InvalidExtension on invalid import
     """
     mocker.patch("ahriman.core.triggers.trigger_loader.importlib.import_module", side_effect=ModuleNotFoundError())
-    with pytest.raises(InvalidExtension):
+    with pytest.raises(ExtensionError):
         trigger_loader.load_trigger("random.module")
 
 
@@ -30,7 +30,7 @@ def test_load_trigger_package_not_trigger(trigger_loader: TriggerLoader) -> None
     """
     must raise InvalidExtension if imported module is not a type
     """
-    with pytest.raises(InvalidExtension):
+    with pytest.raises(ExtensionError):
         trigger_loader.load_trigger("ahriman.core.util.check_output")
 
 
@@ -39,7 +39,7 @@ def test_load_trigger_package_error_on_creation(trigger_loader: TriggerLoader, m
     must raise InvalidException on trigger initialization if any exception is thrown
     """
     mocker.patch("ahriman.core.triggers.trigger.Trigger.__init__", side_effect=Exception())
-    with pytest.raises(InvalidExtension):
+    with pytest.raises(ExtensionError):
         trigger_loader.load_trigger("ahriman.core.report.ReportTrigger")
 
 
@@ -47,7 +47,7 @@ def test_load_trigger_package_is_not_trigger(trigger_loader: TriggerLoader) -> N
     """
     must raise InvalidExtension if loaded class is not a trigger
     """
-    with pytest.raises(InvalidExtension):
+    with pytest.raises(ExtensionError):
         trigger_loader.load_trigger("ahriman.core.sign.gpg.GPG")
 
 
@@ -64,7 +64,7 @@ def test_load_trigger_path_directory(trigger_loader: TriggerLoader, resource_pat
     must raise InvalidExtension if provided import path is directory
     """
     path = resource_path_root.parent.parent / "src" / "ahriman" / "core" / "report"
-    with pytest.raises(InvalidExtension):
+    with pytest.raises(ExtensionError):
         trigger_loader.load_trigger(f"{path}.ReportTrigger")
 
 
@@ -72,7 +72,7 @@ def test_load_trigger_path_not_found(trigger_loader: TriggerLoader) -> None:
     """
     must raise InvalidExtension if file cannot be found
     """
-    with pytest.raises(InvalidExtension):
+    with pytest.raises(ExtensionError):
         trigger_loader.load_trigger("/some/random/path.py.SomeRandomModule")
 
 

--- a/tests/ahriman/core/upload/test_github.py
+++ b/tests/ahriman/core/upload/test_github.py
@@ -4,7 +4,7 @@ import requests
 from pathlib import Path
 from pytest_mock import MockerFixture
 from typing import Any, Dict
-from unittest import mock
+from unittest.mock import call as MockCall
 
 from ahriman.core.upload.github import Github
 
@@ -52,8 +52,8 @@ def test_asset_upload_with_removal(github: Github, github_release: Dict[str, Any
     github.asset_upload(github_release, Path("asset_name"))
     github.asset_upload(github_release, Path("/root/asset_name"))
     remove_mock.assert_has_calls([
-        mock.call(github_release, "asset_name"),
-        mock.call(github_release, "asset_name"),
+        MockCall(github_release, "asset_name"),
+        MockCall(github_release, "asset_name"),
     ])
 
 
@@ -105,8 +105,8 @@ def test_files_upload(github: Github, github_release: Dict[str, Any], mocker: Mo
     upload_mock = mocker.patch("ahriman.core.upload.github.Github.asset_upload")
     github.files_upload(github_release, {Path("a"): "a", Path("b"): "c", Path("c"): "c"}, {"a": "a", "b": "b"})
     upload_mock.assert_has_calls([
-        mock.call(github_release, Path("b")),
-        mock.call(github_release, Path("c")),
+        MockCall(github_release, Path("b")),
+        MockCall(github_release, Path("c")),
     ])
 
 

--- a/tests/ahriman/core/upload/test_s3.py
+++ b/tests/ahriman/core/upload/test_s3.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from pytest_mock import MockerFixture
 from typing import Any, List, Optional, Tuple
-from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call as MockCall
 
 from ahriman.core.upload.s3 import S3
 
@@ -67,11 +66,11 @@ def test_files_upload(s3: S3, s3_remote_objects: List[Any], mocker: MockerFixtur
     s3.files_upload(root, local_files, remote_objects)
     upload_mock.upload_file.assert_has_calls(
         [
-            mock.call(
+            MockCall(
                 Filename=str(root / s3.architecture / "b"),
                 Key=f"{s3.architecture}/{s3.architecture}/b",
                 ExtraArgs={"ContentType": "text/html"}),
-            mock.call(
+            MockCall(
                 Filename=str(root / s3.architecture / "d"),
                 Key=f"{s3.architecture}/{s3.architecture}/d",
                 ExtraArgs=None),

--- a/tests/ahriman/core/upload/test_upload.py
+++ b/tests/ahriman/core/upload/test_upload.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pytest_mock import MockerFixture
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import SyncFailed
+from ahriman.core.exceptions import SynchronizationError
 from ahriman.core.upload.upload import Upload
 from ahriman.models.upload_settings import UploadSettings
 
@@ -14,7 +14,7 @@ def test_upload_failure(configuration: Configuration, mocker: MockerFixture) -> 
     must raise SyncFailed on errors
     """
     mocker.patch("ahriman.core.upload.rsync.Rsync.sync", side_effect=Exception())
-    with pytest.raises(SyncFailed):
+    with pytest.raises(SynchronizationError):
         Upload.load("x86_64", configuration, "rsync").run(Path("path"), [])
 
 

--- a/tests/ahriman/models/test_package.py
+++ b/tests/ahriman/models/test_package.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 from unittest.mock import MagicMock
 
 from ahriman.core.alpm.pacman import Pacman
-from ahriman.core.exceptions import InvalidPackageInfo
+from ahriman.core.exceptions import PackageInfoError
 from ahriman.models.aur_package import AURPackage
 from ahriman.models.package import Package
 from ahriman.models.repository_paths import RepositoryPaths
@@ -114,7 +114,7 @@ def test_from_build_failed(package_ahriman: Package, mocker: MockerFixture) -> N
     mocker.patch("ahriman.models.package.Package._check_output", return_value="")
     mocker.patch("ahriman.models.package.parse_srcinfo", return_value=({"packages": {}}, ["an error"]))
 
-    with pytest.raises(InvalidPackageInfo):
+    with pytest.raises(PackageInfoError):
         Package.from_build(Path("path"))
 
 
@@ -159,7 +159,7 @@ def test_dependencies_failed(mocker: MockerFixture) -> None:
     mocker.patch("ahriman.models.package.Package._check_output", return_value="")
     mocker.patch("ahriman.models.package.parse_srcinfo", return_value=({"packages": {}}, ["an error"]))
 
-    with pytest.raises(InvalidPackageInfo):
+    with pytest.raises(PackageInfoError):
         Package.dependencies(Path("path"))
 
 
@@ -200,7 +200,7 @@ def test_supported_architectures_failed(mocker: MockerFixture) -> None:
     mocker.patch("ahriman.models.package.Package._check_output", return_value="")
     mocker.patch("ahriman.models.package.parse_srcinfo", return_value=({"packages": {}}, ["an error"]))
 
-    with pytest.raises(InvalidPackageInfo):
+    with pytest.raises(PackageInfoError):
         Package.supported_architectures(Path("path"))
 
 

--- a/tests/ahriman/models/test_repository_paths.py
+++ b/tests/ahriman/models/test_repository_paths.py
@@ -3,10 +3,9 @@ import pytest
 from pathlib import Path
 from pytest_mock import MockerFixture
 from typing import Callable, Tuple
-from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call as MockCall
 
-from ahriman.core.exceptions import InvalidPath
+from ahriman.core.exceptions import PathError
 from ahriman.models.package import Package
 from ahriman.models.repository_paths import RepositoryPaths
 
@@ -89,8 +88,8 @@ def test_chown_parent(repository_paths: RepositoryPaths, mocker: MockerFixture) 
     path = repository_paths.root / "parent" / "path"
     repository_paths.chown(path)
     chown_mock.assert_has_calls([
-        mock.call(path, 42, 42, follow_symlinks=False),
-        mock.call(path.parent, 42, 42, follow_symlinks=False)
+        MockCall(path, 42, 42, follow_symlinks=False),
+        MockCall(path.parent, 42, 42, follow_symlinks=False)
     ])
 
 
@@ -111,7 +110,7 @@ def test_chown_invalid_path(repository_paths: RepositoryPaths) -> None:
     """
     must raise invalid path exception in case if directory outside the root supplied
     """
-    with pytest.raises(InvalidPath):
+    with pytest.raises(PathError):
         repository_paths.chown(repository_paths.root.parent)
 
 
@@ -128,7 +127,7 @@ def test_tree_clear(repository_paths: RepositoryPaths, package_ahriman: Package,
     repository_paths.tree_clear(package_ahriman.base)
     rmtree_mock.assert_has_calls(
         [
-            mock.call(path, ignore_errors=True) for path in paths
+            MockCall(path, ignore_errors=True) for path in paths
         ], any_order=True)
 
 
@@ -154,5 +153,5 @@ def test_tree_create(repository_paths: RepositoryPaths, mocker: MockerFixture) -
     chown_mock = mocker.patch("ahriman.models.repository_paths.RepositoryPaths.chown")
 
     repository_paths.tree_create()
-    mkdir_mock.assert_has_calls([mock.call(mode=0o755, parents=True, exist_ok=True) for _ in paths], any_order=True)
-    chown_mock.assert_has_calls([mock.call(pytest.helpers.anyvar(int)) for _ in paths], any_order=True)
+    mkdir_mock.assert_has_calls([MockCall(mode=0o755, parents=True, exist_ok=True) for _ in paths], any_order=True)
+    chown_mock.assert_has_calls([MockCall(pytest.helpers.anyvar(int)) for _ in paths], any_order=True)

--- a/tests/ahriman/models/test_result.py
+++ b/tests/ahriman/models/test_result.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ahriman.core.exceptions import SuccessFailed
+from ahriman.core.exceptions import UnprocessedPackageStatusError
 from ahriman.models.package import Package
 from ahriman.models.result import Result
 
@@ -99,7 +99,7 @@ def test_merge_exception(package_ahriman: Package) -> None:
     right = Result()
     right.add_success(package_ahriman)
 
-    with pytest.raises(SuccessFailed):
+    with pytest.raises(UnprocessedPackageStatusError):
         left.merge(right)
 
 

--- a/tests/ahriman/web/test_web.py
+++ b/tests/ahriman/web/test_web.py
@@ -3,7 +3,7 @@ import pytest
 from aiohttp import web
 from pytest_mock import MockerFixture
 
-from ahriman.core.exceptions import InitializeException
+from ahriman.core.exceptions import InitializeError
 from ahriman.core.status.watcher import Watcher
 from ahriman.web.web import on_shutdown, on_startup, run_server
 
@@ -35,7 +35,7 @@ async def test_on_startup_exception(application: web.Application, watcher: Watch
     mocker.patch("aiohttp.web.Application.__getitem__", return_value=watcher)
     mocker.patch("ahriman.core.status.watcher.Watcher.load", side_effect=Exception())
 
-    with pytest.raises(InitializeException):
+    with pytest.raises(InitializeError):
         await on_startup(application)
 
 


### PR DESCRIPTION
## Summary

This mr replaces several old store_true keys (such as --no-aur) with their BooleanOptionalAction alternative. It will allow to use either `--aur` or `--no-aur` option in command line in order to allow to specify behavior explicitly. Closes #73 

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
