### PR TITLE
update dependencies before build

### DIFF
--- a/src/ahriman/application/ahriman.py
+++ b/src/ahriman/application/ahriman.py
@@ -245,6 +245,8 @@ def _set_package_add_parser(root: SubParserAction) -> argparse.ArgumentParser:
                                     "5) and finally you can add package from AUR.",
                              formatter_class=_formatter)
     parser.add_argument("package", help="package source (base name, path to local files, remote URL)", nargs="+")
+    parser.add_argument("--dependencies", help="process missing package dependencies",
+                        action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("-e", "--exit-code", help="return non-zero exit status if result is empty", action="store_true")
     parser.add_argument("-n", "--now", help="run update function after", action="store_true")
     parser.add_argument("-y", "--refresh", help="download fresh package databases from the mirror before actions, "
@@ -252,7 +254,6 @@ def _set_package_add_parser(root: SubParserAction) -> argparse.ArgumentParser:
                         action="count", default=False)
     parser.add_argument("-s", "--source", help="explicitly specify the package source for this command",
                         type=PackageSource, choices=enum_values(PackageSource), default=PackageSource.Auto)
-    parser.add_argument("--without-dependencies", help="do not add dependencies", action="store_true")
     parser.set_defaults(handler=handlers.Add)
     return parser
 
@@ -472,7 +473,7 @@ def _set_repo_check_parser(root: SubParserAction) -> argparse.ArgumentParser:
     parser.add_argument("-y", "--refresh", help="download fresh package databases from the mirror before actions, "
                                                 "-yy to force refresh even if up to date",
                         action="count", default=False)
-    parser.set_defaults(handler=handlers.Update, dry_run=True, aur=True, local=True, manual=False)
+    parser.set_defaults(handler=handlers.Update, dependencies=False, dry_run=True, aur=True, local=True, manual=False)
     return parser
 
 
@@ -491,6 +492,8 @@ def _set_repo_daemon_parser(root: SubParserAction) -> argparse.ArgumentParser:
                              formatter_class=_formatter)
     parser.add_argument("-i", "--interval", help="interval between runs in seconds", type=int, default=60 * 60 * 12)
     parser.add_argument("--aur", help="enable or disable checking for AUR updates",
+                        action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--dependencies", help="process missing package dependencies",
                         action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--local", help="enable or disable checking of local packages for updates",
                         action=argparse.BooleanOptionalAction, default=True)
@@ -691,10 +694,12 @@ def _set_repo_update_parser(root: SubParserAction) -> argparse.ArgumentParser:
                              description="check for packages updates and run build process if requested",
                              formatter_class=_formatter)
     parser.add_argument("package", help="filter check by package base", nargs="*")
-    parser.add_argument("--dry-run", help="just perform check for updates, same as check command", action="store_true")
-    parser.add_argument("-e", "--exit-code", help="return non-zero exit status if result is empty", action="store_true")
     parser.add_argument("--aur", help="enable or disable checking for AUR updates",
                         action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--dependencies", help="process missing package dependencies",
+                        action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--dry-run", help="just perform check for updates, same as check command", action="store_true")
+    parser.add_argument("-e", "--exit-code", help="return non-zero exit status if result is empty", action="store_true")
     parser.add_argument("--local", help="enable or disable checking of local packages for updates",
                         action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--manual", help="include or exclude manual updates",

--- a/src/ahriman/application/handlers/add.py
+++ b/src/ahriman/application/handlers/add.py
@@ -47,11 +47,12 @@ class Add(Handler):
         application = Application(architecture, configuration,
                                   report=report, unsafe=unsafe, refresh_pacman_database=args.refresh)
         application.on_start()
-        application.add(args.package, args.source, args.without_dependencies)
+        application.add(args.package, args.source)
         if not args.now:
             return
 
         packages = application.updates(args.package, aur=False, local=False, manual=True, vcs=False,
                                        log_fn=application.logger.info)
+        packages = application.with_dependencies(packages, process_dependencies=args.dependencies)
         result = application.update(packages)
         Add.check_if_empty(args.exit_code, result.is_empty)

--- a/src/ahriman/application/handlers/update.py
+++ b/src/ahriman/application/handlers/update.py
@@ -53,6 +53,7 @@ class Update(Handler):
         if args.dry_run:
             return
 
+        packages = application.with_dependencies(packages, process_dependencies=args.dependencies)
         result = application.update(packages)
         Update.check_if_empty(args.exit_code, result.is_empty)
 

--- a/src/ahriman/models/package.py
+++ b/src/ahriman/models/package.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-public-methods
 from __future__ import annotations
 
 import copy
@@ -96,7 +96,7 @@ class Package(LazyLogging):
         Returns:
             Set[str]: full dependencies list used by devtools
         """
-        return (set(self.depends) | set(self.depends_make)) - self.packages.keys()
+        return (set(self.depends) | set(self.depends_make)).difference(self.packages_full)
 
     @property
     def depends_make(self) -> List[str]:
@@ -162,6 +162,20 @@ class Package(LazyLogging):
             List[str]: sum of licenses per each package
         """
         return sorted(set(sum((package.licenses for package in self.packages.values()), start=[])))
+
+    @property
+    def packages_full(self) -> List[str]:
+        """
+        get full packages list including provides
+
+        Returns:
+            List[str]: full list of packages which this base contains
+        """
+        packages = set()
+        for package, properties in self.packages.items():
+            packages.add(package)
+            packages.update(properties.provides)
+        return sorted(packages)
 
     @classmethod
     def from_archive(cls: Type[Package], path: Path, pacman: Pacman, remote: Optional[RemoteSource]) -> Package:

--- a/tests/ahriman/application/application/test_application.py
+++ b/tests/ahriman/application/application/test_application.py
@@ -1,4 +1,5 @@
 from pytest_mock import MockerFixture
+from unittest.mock import MagicMock, call as MockCall
 
 from ahriman.application.application import Application
 from ahriman.models.package import Package
@@ -44,3 +45,55 @@ def test_on_stop(application: Application, mocker: MockerFixture) -> None:
 
     application.on_stop()
     triggers_mock.assert_called_once_with()
+
+
+def test_with_dependencies(application: Application, package_ahriman: Package, package_python_schedule: Package,
+                           mocker: MockerFixture) -> None:
+    """
+    must append list of missing dependencies
+    """
+    def create_package_mock(package_base) -> MagicMock:
+        mock = MagicMock()
+        mock.base = package_base
+        mock.depends_build = []
+        mock.packages_full = [package_base]
+        return mock
+
+    package_python_schedule.packages = {
+        package_python_schedule.base: package_python_schedule.packages[package_python_schedule.base]
+    }
+    package_ahriman.packages[package_ahriman.base].depends = ["devtools", "python", package_python_schedule.base]
+    package_ahriman.packages[package_ahriman.base].make_depends = ["python-build", "python-installer"]
+
+    packages = {
+        package_ahriman.base: package_ahriman,
+        package_python_schedule.base: package_python_schedule,
+        "python": create_package_mock("python"),
+        "python-installer": create_package_mock("python-installer"),
+    }
+
+    package_mock = mocker.patch("ahriman.models.package.Package.from_aur", side_effect=lambda p, _: packages[p])
+    packages_mock = mocker.patch("ahriman.application.application.Application._known_packages",
+                                 return_value=["devtools", "python-build"])
+
+    result = application.with_dependencies([package_ahriman], process_dependencies=True)
+    assert {package.base: package for package in result} == packages
+    package_mock.assert_has_calls([
+        MockCall(package_python_schedule.base, application.repository.pacman),
+        MockCall("python", application.repository.pacman),
+        MockCall("python-installer", application.repository.pacman),
+    ], any_order=True)
+    packages_mock.assert_called_once_with()
+
+
+def test_with_dependencies_skip(application: Application, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must skip processing of dependencies
+    """
+    packages_mock = mocker.patch("ahriman.application.application.Application._known_packages")
+
+    assert application.with_dependencies([package_ahriman], process_dependencies=False) == [package_ahriman]
+    packages_mock.assert_not_called()
+
+    assert application.with_dependencies([], process_dependencies=True) == []
+    packages_mock.assert_not_called()

--- a/tests/ahriman/application/test_ahriman.py
+++ b/tests/ahriman/application/test_ahriman.py
@@ -342,9 +342,10 @@ def test_subparsers_repo_backup_architecture(parser: argparse.ArgumentParser) ->
 
 def test_subparsers_repo_check(parser: argparse.ArgumentParser) -> None:
     """
-    repo-check command must imply dry-run, aur and manual
+    repo-check command must imply dependencies, dry-run, aur and manual
     """
     args = parser.parse_args(["repo-check"])
+    assert not args.dependencies
     assert args.dry_run
     assert args.aur
     assert not args.manual

--- a/tests/ahriman/models/test_package.py
+++ b/tests/ahriman/models/test_package.py
@@ -125,6 +125,14 @@ def test_licenses(package_ahriman: Package) -> None:
     assert sorted(package_ahriman.licenses) == package_ahriman.licenses
 
 
+def test_packages_full(package_ahriman: Package) -> None:
+    """
+    must return full list of packages including provides
+    """
+    package_ahriman.packages[package_ahriman.base].provides = [f"{package_ahriman.base}-git"]
+    assert package_ahriman.packages_full == [package_ahriman.base, f"{package_ahriman.base}-git"]
+
+
 def test_from_archive(package_ahriman: Package, pyalpm_handle: MagicMock, mocker: MockerFixture) -> None:
     """
     must construct package from alpm library


### PR DESCRIPTION
## Summary

Old implementation has used add step in order to fetch dependencies, which could lead to build errors in case if dependency list was updated.

New solution uses dependencies which are declared at current version and fetch them (if required and if enabled) before update process.

Closes #90

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
