### PR TITLE
mimic parent arguments during spawn process

### DIFF
--- a/src/ahriman/application/handlers/unsafe_commands.py
+++ b/src/ahriman/application/handlers/unsafe_commands.py
@@ -79,5 +79,6 @@ class UnsafeCommands(Handler):
         """
         # should never fail
         # pylint: disable=protected-access
-        subparser = next(action for action in parser._actions if isinstance(action, argparse._SubParsersAction))
-        return sorted(action_name for action_name, action in subparser.choices.items() if action.get_default("unsafe"))
+        subparser = next((action for action in parser._actions if isinstance(action, argparse._SubParsersAction)), None)
+        actions = subparser.choices if subparser is not None else {}
+        return sorted(action_name for action_name, action in actions.items() if action.get_default("unsafe"))

--- a/tests/ahriman/application/handlers/test_handler_web.py
+++ b/tests/ahriman/application/handlers/test_handler_web.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 from ahriman.application.handlers import Web
 from ahriman.core.configuration import Configuration
 from ahriman.core.repository import Repository
+from ahriman.models.log_handler import LogHandler
 
 
 def _default_args(args: argparse.Namespace) -> argparse.Namespace:
@@ -19,6 +20,11 @@ def _default_args(args: argparse.Namespace) -> argparse.Namespace:
         argparse.Namespace: generated arguments for these test cases
     """
     args.parser = lambda: True
+    args.force = False
+    args.log_handler = None
+    args.report = True
+    args.quiet = False
+    args.unsafe = False
     return args
 
 
@@ -41,6 +47,63 @@ def test_run(args: argparse.Namespace, configuration: Configuration, repository:
     start_mock.assert_called_once_with()
     stop_mock.assert_called_once_with()
     join_mock.assert_called_once_with()
+
+
+def test_extract_arguments(args: argparse.Namespace, configuration: Configuration):
+    """
+    must extract correct args
+    """
+    expected = [
+        "--architecture", "x86_64",
+        "--configuration", str(configuration.path),
+    ]
+
+    probe = _default_args(args)
+    assert list(Web.extract_arguments(probe, "x86_64", configuration)) == expected
+
+    probe.force = True
+    expected.extend(["--force"])
+    assert list(Web.extract_arguments(probe, "x86_64", configuration)) == expected
+
+    probe.log_handler = LogHandler.Console
+    expected.extend(["--log-handler", probe.log_handler.value])
+    assert list(Web.extract_arguments(probe, "x86_64", configuration)) == expected
+
+    probe.quiet = True
+    expected.extend(["--quiet"])
+    assert list(Web.extract_arguments(probe, "x86_64", configuration)) == expected
+
+    probe.unsafe = True
+    expected.extend(["--unsafe"])
+    assert list(Web.extract_arguments(probe, "x86_64", configuration)) == expected
+
+
+def test_extract_arguments_full(parser: argparse.ArgumentParser, configuration: Configuration):
+    """
+    must extract all available args except for blacklisted
+    """
+    # append all options from parser
+    args = argparse.Namespace()
+    for action in parser._actions:
+        if action.default == argparse.SUPPRESS:
+            continue
+        # extract option from the following list
+        value = action.const or \
+            next(iter(action.choices or []), None) or \
+            (not action.default if isinstance(action.default, bool) else None) or \
+            "random string"
+        if action.type is not None:
+            value = action.type(value)
+        setattr(args, action.dest, value)
+
+    assert list(Web.extract_arguments(args, "x86_64", configuration)) == [
+        "--architecture", "x86_64",
+        "--configuration", str(configuration.path),
+        "--force",
+        "--log-handler", "console",
+        "--quiet",
+        "--unsafe",
+    ]
 
 
 def test_disallow_auto_architecture_run() -> None:

--- a/tests/ahriman/conftest.py
+++ b/tests/ahriman/conftest.py
@@ -482,7 +482,7 @@ def spawner(configuration: Configuration) -> Spawn:
     Returns:
         Spawn: spawner fixture
     """
-    return Spawn(MagicMock(), "x86_64", configuration)
+    return Spawn(MagicMock(), "x86_64", ["--architecture", "x86_64", "--configuration", str(configuration.path)])
 
 
 @pytest.fixture

--- a/tests/ahriman/core/test_spawn.py
+++ b/tests/ahriman/core/test_spawn.py
@@ -44,10 +44,11 @@ def test_spawn_process(spawner: Spawn, mocker: MockerFixture) -> None:
 
     spawner._spawn_process("add", "ahriman", now="", maybe="?")
     start_mock.assert_called_once_with()
-    spawner.args_parser.parse_args.assert_called_once_with([
-        "--architecture", spawner.architecture, "--configuration", str(spawner.configuration.path),
-        "add", "ahriman", "--now", "--maybe", "?"
-    ])
+    spawner.args_parser.parse_args.assert_called_once_with(
+        spawner.command_arguments + [
+            "add", "ahriman", "--now", "--maybe", "?"
+        ]
+    )
 
 
 def test_key_import(spawner: Spawn, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary

With current implementation we don't copy all available arguments (such as logging) are not copied to child process. This mr implements full argument copying

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
