### PR TITLE
Load http views dynamically

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1303,6 +1303,18 @@ It is possible to customize html templates. In order to do so, create files some
 
 In addition, default html templates supports style customization out-of-box. In order to customize style, just put file named ``user-style.jinja2`` to the templates directory.
 
+Web API extension
+^^^^^^^^^^^^^^^^^
+
+The application loads web views dynamically, so it is possible relatively easy extend its API. In order to do so:
+
+#. Create view class which is derived from ``ahriman.web.views.base.BaseView`` class.
+#. Create implementation for this class.
+#. Put file into ``ahriman.web.views`` package.
+#. Restart application.
+
+For more details about implementation and possibilities, kindly refer to module documentation and source code and `aiohttp documentation <https://docs.aiohttp.org/en/stable/>`_.
+
 I did not find my question
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/ahriman/core/database/migrations/__init__.py
+++ b/src/ahriman/core/database/migrations/__init__.py
@@ -92,6 +92,7 @@ class Migrations(LazyLogging):
             list[Migration]: list of found migrations
         """
         migrations: list[Migration] = []
+
         package_dir = Path(__file__).resolve().parent
         modules = [module_name for (_, module_name, _) in iter_modules([str(package_dir)])]
 

--- a/src/ahriman/web/views/api/docs.py
+++ b/src/ahriman/web/views/api/docs.py
@@ -34,6 +34,7 @@ class DocsView(BaseView):
     """
 
     GET_PERMISSION = UserAccess.Unauthorized
+    ROUTES = ["/api-docs"]
 
     @aiohttp_jinja2.template("api.jinja2")
     async def get(self) -> dict[str, Any]:

--- a/src/ahriman/web/views/api/swagger.py
+++ b/src/ahriman/web/views/api/swagger.py
@@ -34,6 +34,7 @@ class SwaggerView(BaseView):
     """
 
     GET_PERMISSION = UserAccess.Unauthorized
+    ROUTES = ["/api-docs/swagger.json"]
 
     async def get(self) -> Response:
         """

--- a/src/ahriman/web/views/base.py
+++ b/src/ahriman/web/views/base.py
@@ -38,9 +38,11 @@ class BaseView(View, CorsViewMixin):
 
     Attributes:
         OPTIONS_PERMISSION(UserAccess): (class attribute) options permissions of self
+        ROUTES(list[str]): (class attribute) list of supported routes
     """
 
     OPTIONS_PERMISSION = UserAccess.Unauthorized
+    ROUTES: list[str] = []
 
     @property
     def configuration(self) -> Configuration:

--- a/src/ahriman/web/views/index.py
+++ b/src/ahriman/web/views/index.py
@@ -44,6 +44,7 @@ class IndexView(BaseView):
     """
 
     GET_PERMISSION = UserAccess.Unauthorized
+    ROUTES = ["/", "/index.html"]
 
     @aiohttp_jinja2.template("build-status.jinja2")
     async def get(self) -> dict[str, Any]:

--- a/src/ahriman/web/views/v1/__init__.py
+++ b/src/ahriman/web/views/v1/__init__.py
@@ -17,20 +17,3 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from ahriman.web.views.v1.service.add import AddView
-from ahriman.web.views.v1.service.pgp import PGPView
-from ahriman.web.views.v1.service.process import ProcessView
-from ahriman.web.views.v1.service.rebuild import RebuildView
-from ahriman.web.views.v1.service.remove import RemoveView
-from ahriman.web.views.v1.service.request import RequestView
-from ahriman.web.views.v1.service.search import SearchView
-from ahriman.web.views.v1.service.update import UpdateView
-from ahriman.web.views.v1.service.upload import UploadView
-
-from ahriman.web.views.v1.status.logs import LogsView
-from ahriman.web.views.v1.status.package import PackageView
-from ahriman.web.views.v1.status.packages import PackagesView
-from ahriman.web.views.v1.status.status import StatusView
-
-from ahriman.web.views.v1.user.login import LoginView
-from ahriman.web.views.v1.user.logout import LogoutView

--- a/src/ahriman/web/views/v1/service/add.py
+++ b/src/ahriman/web/views/v1/service/add.py
@@ -35,6 +35,7 @@ class AddView(BaseView):
     """
 
     POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/service/add"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/pgp.py
+++ b/src/ahriman/web/views/v1/service/pgp.py
@@ -35,8 +35,9 @@ class PGPView(BaseView):
         POST_PERMISSION(UserAccess): (class attribute) post permissions of self
     """
 
-    POST_PERMISSION = UserAccess.Full
     GET_PERMISSION = UserAccess.Reporter
+    POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/service/pgp"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/process.py
+++ b/src/ahriman/web/views/v1/service/process.py
@@ -35,6 +35,7 @@ class ProcessView(BaseView):
     """
 
     GET_PERMISSION = UserAccess.Reporter
+    ROUTES = ["/api/v1/service/process/{process_id}"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/rebuild.py
+++ b/src/ahriman/web/views/v1/service/rebuild.py
@@ -35,6 +35,7 @@ class RebuildView(BaseView):
     """
 
     POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/service/rebuild"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/remove.py
+++ b/src/ahriman/web/views/v1/service/remove.py
@@ -35,6 +35,7 @@ class RemoveView(BaseView):
     """
 
     POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/service/remove"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/request.py
+++ b/src/ahriman/web/views/v1/service/request.py
@@ -35,6 +35,7 @@ class RequestView(BaseView):
     """
 
     POST_PERMISSION = UserAccess.Reporter
+    ROUTES = ["/api/v1/service/request"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/search.py
+++ b/src/ahriman/web/views/v1/service/search.py
@@ -38,6 +38,7 @@ class SearchView(BaseView):
     """
 
     GET_PERMISSION = UserAccess.Reporter
+    ROUTES = ["/api/v1/service/search"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/update.py
+++ b/src/ahriman/web/views/v1/service/update.py
@@ -35,6 +35,7 @@ class UpdateView(BaseView):
     """
 
     POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/service/update"]
 
     @aiohttp_apispec.docs(
         tags=["Actions"],

--- a/src/ahriman/web/views/v1/service/upload.py
+++ b/src/ahriman/web/views/v1/service/upload.py
@@ -39,6 +39,7 @@ class UploadView(BaseView):
     """
 
     POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/service/upload"]
 
     @staticmethod
     async def save_file(part: BodyPartReader, target: Path, *, max_body_size: int | None = None) -> tuple[str, Path]:

--- a/src/ahriman/web/views/v1/status/logs.py
+++ b/src/ahriman/web/views/v1/status/logs.py
@@ -41,6 +41,7 @@ class LogsView(BaseView):
 
     DELETE_PERMISSION = POST_PERMISSION = UserAccess.Full
     GET_PERMISSION = UserAccess.Reporter
+    ROUTES = ["/api/v1/packages/{package}/logs"]
 
     @aiohttp_apispec.docs(
         tags=["Packages"],

--- a/src/ahriman/web/views/v1/status/package.py
+++ b/src/ahriman/web/views/v1/status/package.py
@@ -41,6 +41,7 @@ class PackageView(BaseView):
 
     DELETE_PERMISSION = POST_PERMISSION = UserAccess.Full
     GET_PERMISSION = UserAccess.Read
+    ROUTES = ["/api/v1/packages/{package}"]
 
     @aiohttp_apispec.docs(
         tags=["Packages"],

--- a/src/ahriman/web/views/v1/status/packages.py
+++ b/src/ahriman/web/views/v1/status/packages.py
@@ -41,6 +41,7 @@ class PackagesView(BaseView):
 
     GET_PERMISSION = UserAccess.Read
     POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/packages"]
 
     @aiohttp_apispec.docs(
         tags=["Packages"],

--- a/src/ahriman/web/views/v1/status/status.py
+++ b/src/ahriman/web/views/v1/status/status.py
@@ -41,6 +41,7 @@ class StatusView(BaseView):
 
     GET_PERMISSION = UserAccess.Read
     POST_PERMISSION = UserAccess.Full
+    ROUTES = ["/api/v1/status"]
 
     @aiohttp_apispec.docs(
         tags=["Status"],

--- a/src/ahriman/web/views/v1/user/login.py
+++ b/src/ahriman/web/views/v1/user/login.py
@@ -37,6 +37,7 @@ class LoginView(BaseView):
     """
 
     GET_PERMISSION = POST_PERMISSION = UserAccess.Unauthorized
+    ROUTES = ["/api/v1/login"]
 
     @aiohttp_apispec.docs(
         tags=["Login"],

--- a/src/ahriman/web/views/v1/user/logout.py
+++ b/src/ahriman/web/views/v1/user/logout.py
@@ -36,6 +36,7 @@ class LogoutView(BaseView):
     """
 
     POST_PERMISSION = UserAccess.Unauthorized
+    ROUTES = ["/api/v1/logout"]
 
     @aiohttp_apispec.docs(
         tags=["Login"],

--- a/src/ahriman/web/views/v2/__init__.py
+++ b/src/ahriman/web/views/v2/__init__.py
@@ -17,4 +17,3 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from ahriman.web.views.v2.status.logs import LogsView

--- a/src/ahriman/web/views/v2/status/logs.py
+++ b/src/ahriman/web/views/v2/status/logs.py
@@ -37,6 +37,7 @@ class LogsView(BaseView):
     """
 
     GET_PERMISSION = UserAccess.Reporter
+    ROUTES = ["/api/v2/packages/{package}/logs"]
 
     @aiohttp_apispec.docs(
         tags=["Packages"],

--- a/tests/ahriman/web/conftest.py
+++ b/tests/ahriman/web/conftest.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from marshmallow import Schema
 from pytest_mock import MockerFixture
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import ahriman.core.auth.helpers
 
@@ -18,6 +18,26 @@ from ahriman.core.repository import Repository
 from ahriman.core.spawn import Spawn
 from ahriman.models.user import User
 from ahriman.web.web import setup_service
+
+
+@pytest.helpers.register
+def patch_view(application: Application, attribute: str, mock: Mock) -> Mock:
+    """
+    patch given attribute in views. This method is required because of dynamic load
+
+    Args:
+        application(Application): application fixture
+        attribute(str): attribute name to patch
+        mock(Mock): mock object
+
+    Returns:
+        Mock: mock set to object
+    """
+    for route in application.router.routes():
+        if hasattr(route.handler, attribute):
+            setattr(route.handler, attribute, mock)
+
+    return mock
 
 
 @pytest.helpers.register

--- a/tests/ahriman/web/test_routes.py
+++ b/tests/ahriman/web/test_routes.py
@@ -1,7 +1,73 @@
+import pytest
+
 from aiohttp.web import Application
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from pytest_mock import MockerFixture
+from types import ModuleType
 
 from ahriman.core.configuration import Configuration
-from ahriman.web.routes import setup_routes
+from ahriman.core.util import walk
+from ahriman.web.routes import _dynamic_routes, _module, _modules, setup_routes
+
+
+def test_dynamic_routes(resource_path_root: Path) -> None:
+    """
+    must return all available routes
+    """
+    views_root = resource_path_root / ".." / ".." / "src" / "ahriman" / "web" / "views"
+    expected_views = [
+        file
+        for file in walk(views_root)
+        if file.suffix == ".py" and file.name not in ("__init__.py", "base.py")
+    ]
+
+    routes = _dynamic_routes(views_root)
+    assert all(isinstance(view, type) for view in routes.values())
+    assert len(set(routes.values())) == len(expected_views)
+
+
+def test_module(mocker: MockerFixture) -> None:
+    """
+    must load module
+    """
+    exec_mock = mocker.patch("importlib.machinery.SourceFileLoader.exec_module")
+    module_info = next(_modules(Path(__file__).parent))
+
+    module = _module(module_info)
+    assert isinstance(module, ModuleType)
+    exec_mock.assert_called_once_with(pytest.helpers.anyvar(int))
+
+
+def test_module_no_spec(mocker: MockerFixture) -> None:
+    """
+    must raise ValueError if spec is not available
+    """
+    mocker.patch("importlib.machinery.FileFinder.find_spec", return_value=None)
+    module_info = next(_modules(Path(__file__).parent))
+
+    with pytest.raises(ValueError):
+        _module(module_info)
+
+
+def test_module_no_loader(mocker: MockerFixture) -> None:
+    """
+    must raise ValueError if loader is not available
+    """
+    mocker.patch("importlib.machinery.FileFinder.find_spec", return_value=ModuleSpec("name", None))
+    module_info = next(_modules(Path(__file__).parent))
+
+    with pytest.raises(ValueError):
+        _module(module_info)
+
+
+def test_modules() -> None:
+    """
+    must load modules
+    """
+    modules = list(_modules(Path(__file__).parent.parent))
+    assert modules
+    assert all(not module.ispkg for module in modules)
 
 
 def test_setup_routes(application: Application, configuration: Configuration) -> None:

--- a/tests/ahriman/web/views/test_view_base.py
+++ b/tests/ahriman/web/views/test_view_base.py
@@ -10,6 +10,13 @@ from ahriman.models.user_access import UserAccess
 from ahriman.web.views.base import BaseView
 
 
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert BaseView.ROUTES == []
+
+
 def test_configuration(base: BaseView) -> None:
     """
     must return configuration

--- a/tests/ahriman/web/views/test_view_index.py
+++ b/tests/ahriman/web/views/test_view_index.py
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
         assert await IndexView.get_permission(request) == UserAccess.Unauthorized
 
 
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert IndexView.ROUTES == ["/", "/index.html"]
+
+
 async def test_get(client_with_auth: TestClient) -> None:
     """
     must generate status page correctly (/)

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_add.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_add.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 from unittest.mock import AsyncMock
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import AddView
+from ahriman.web.views.v1.service.add import AddView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await AddView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert AddView.ROUTES == ["/api/v1/service/add"]
 
 
 async def test_post(client: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_pgp.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_pgp.py
@@ -4,7 +4,7 @@ from aiohttp.test_utils import TestClient
 from pytest_mock import MockerFixture
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import PGPView
+from ahriman.web.views.v1.service.pgp import PGPView
 
 
 async def test_get_permission() -> None:
@@ -17,6 +17,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await PGPView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert PGPView.ROUTES == ["/api/v1/service/pgp"]
 
 
 async def test_get(client: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_process.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_process.py
@@ -4,7 +4,7 @@ from aiohttp.test_utils import TestClient
 from pytest_mock import MockerFixture
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import ProcessView
+from ahriman.web.views.v1.service.process import ProcessView
 
 
 async def test_get_permission() -> None:
@@ -14,6 +14,13 @@ async def test_get_permission() -> None:
     for method in ("GET",):
         request = pytest.helpers.request("", "", method)
         assert await ProcessView.get_permission(request) == UserAccess.Reporter
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert ProcessView.ROUTES == ["/api/v1/service/process/{process_id}"]
 
 
 async def test_get(client: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_rebuild.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_rebuild.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 from unittest.mock import AsyncMock
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import RebuildView
+from ahriman.web.views.v1.service.rebuild import RebuildView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await RebuildView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert RebuildView.ROUTES == ["/api/v1/service/rebuild"]
 
 
 async def test_post(client: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_remove.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_remove.py
@@ -4,7 +4,7 @@ from aiohttp.test_utils import TestClient
 from pytest_mock import MockerFixture
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import RemoveView
+from ahriman.web.views.v1.service.remove import RemoveView
 
 
 async def test_get_permission() -> None:
@@ -14,6 +14,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await RemoveView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert RemoveView.ROUTES == ["/api/v1/service/remove"]
 
 
 async def test_post(client: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_request.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_request.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 from unittest.mock import AsyncMock
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import RequestView
+from ahriman.web.views.v1.service.request import RequestView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await RequestView.get_permission(request) == UserAccess.Reporter
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert RequestView.ROUTES == ["/api/v1/service/request"]
 
 
 async def test_post(client: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_search.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_search.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 
 from ahriman.models.aur_package import AURPackage
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import SearchView
+from ahriman.web.views.v1.service.search import SearchView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("GET",):
         request = pytest.helpers.request("", "", method)
         assert await SearchView.get_permission(request) == UserAccess.Reporter
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert SearchView.ROUTES == ["/api/v1/service/search"]
 
 
 async def test_get(client: TestClient, aur_package_ahriman: AURPackage, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_update.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_update.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 from unittest.mock import AsyncMock
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import UpdateView
+from ahriman.web.views.v1.service.update import UpdateView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await UpdateView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert UpdateView.ROUTES == ["/api/v1/service/update"]
 
 
 async def test_post(client: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v1/service/test_view_v1_service_upload.py
+++ b/tests/ahriman/web/views/v1/service/test_view_v1_service_upload.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, call as MockCall
 
 from ahriman.models.repository_paths import RepositoryPaths
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import UploadView
+from ahriman.web.views.v1.service.upload import UploadView
 
 
 async def test_get_permission() -> None:
@@ -20,6 +20,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await UploadView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert UploadView.ROUTES == ["/api/v1/service/upload"]
 
 
 async def test_save_file(mocker: MockerFixture) -> None:
@@ -84,8 +91,8 @@ async def test_post(client: TestClient, repository_paths: RepositoryPaths, mocke
     must process file upload via http
     """
     local = Path("local")
-    save_mock = mocker.patch("ahriman.web.views.v1.UploadView.save_file",
-                             side_effect=AsyncMock(return_value=("filename", local / ".filename")))
+    save_mock = pytest.helpers.patch_view(client.app, "save_file",
+                                          AsyncMock(return_value=("filename", local / ".filename")))
     rename_mock = mocker.patch("pathlib.Path.rename")
     # no content validation here because it has invalid schema
 
@@ -103,11 +110,11 @@ async def test_post_with_sig(client: TestClient, repository_paths: RepositoryPat
     must process file upload with signature via http
     """
     local = Path("local")
-    save_mock = mocker.patch("ahriman.web.views.v1.UploadView.save_file",
-                             side_effect=AsyncMock(side_effect=[
-                                 ("filename", local / ".filename"),
-                                 ("filename.sig", local / ".filename.sig"),
-                             ]))
+    save_mock = pytest.helpers.patch_view(client.app, "save_file",
+                                          AsyncMock(side_effect=[
+                                              ("filename", local / ".filename"),
+                                              ("filename.sig", local / ".filename.sig"),
+                                          ]))
     rename_mock = mocker.patch("pathlib.Path.rename")
     # no content validation here because it has invalid schema
 

--- a/tests/ahriman/web/views/v1/status/test_view_v1_status_logs.py
+++ b/tests/ahriman/web/views/v1/status/test_view_v1_status_logs.py
@@ -5,7 +5,7 @@ from aiohttp.test_utils import TestClient
 from ahriman.models.build_status import BuildStatusEnum
 from ahriman.models.package import Package
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import LogsView
+from ahriman.web.views.v1.status.logs import LogsView
 
 
 async def test_get_permission() -> None:
@@ -18,6 +18,13 @@ async def test_get_permission() -> None:
     for method in ("DELETE", "POST"):
         request = pytest.helpers.request("", "", method)
         assert await LogsView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert LogsView.ROUTES == ["/api/v1/packages/{package}/logs"]
 
 
 async def test_delete(client: TestClient, package_ahriman: Package, package_python_schedule: Package) -> None:

--- a/tests/ahriman/web/views/v1/status/test_view_v1_status_package.py
+++ b/tests/ahriman/web/views/v1/status/test_view_v1_status_package.py
@@ -5,7 +5,7 @@ from aiohttp.test_utils import TestClient
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.package import Package
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import PackageView
+from ahriman.web.views.v1.status.package import PackageView
 
 
 async def test_get_permission() -> None:
@@ -18,6 +18,13 @@ async def test_get_permission() -> None:
     for method in ("DELETE", "POST"):
         request = pytest.helpers.request("", "", method)
         assert await PackageView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert PackageView.ROUTES == ["/api/v1/packages/{package}"]
 
 
 async def test_delete(client: TestClient, package_ahriman: Package, package_python_schedule: Package) -> None:

--- a/tests/ahriman/web/views/v1/status/test_view_v1_status_packages.py
+++ b/tests/ahriman/web/views/v1/status/test_view_v1_status_packages.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from ahriman.models.build_status import BuildStatusEnum
 from ahriman.models.package import Package
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import PackagesView
+from ahriman.web.views.v1.status.packages import (PackagesView)
 
 
 async def test_get_permission() -> None:
@@ -19,6 +19,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await PackagesView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert PackagesView.ROUTES == ["/api/v1/packages"]
 
 
 async def test_get(client: TestClient, package_ahriman: Package, package_python_schedule: Package) -> None:

--- a/tests/ahriman/web/views/v1/status/test_view_v1_status_status.py
+++ b/tests/ahriman/web/views/v1/status/test_view_v1_status_status.py
@@ -8,7 +8,7 @@ from ahriman.models.build_status import BuildStatusEnum
 from ahriman.models.internal_status import InternalStatus
 from ahriman.models.package import Package
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import StatusView
+from ahriman.web.views.v1.status.status import StatusView
 
 
 async def test_get_permission() -> None:
@@ -21,6 +21,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await StatusView.get_permission(request) == UserAccess.Full
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert StatusView.ROUTES == ["/api/v1/status"]
 
 
 async def test_get(client: TestClient, package_ahriman: Package) -> None:

--- a/tests/ahriman/web/views/v1/user/test_view_v1_user_login.py
+++ b/tests/ahriman/web/views/v1/user/test_view_v1_user_login.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 
 from ahriman.models.user import User
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import LoginView
+from ahriman.web.views.v1.user.login import LoginView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("GET", "POST"):
         request = pytest.helpers.request("", "", method)
         assert await LoginView.get_permission(request) == UserAccess.Unauthorized
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert LoginView.ROUTES == ["/api/v1/login"]
 
 
 async def test_get_default_validator(client_with_auth: TestClient) -> None:

--- a/tests/ahriman/web/views/v1/user/test_view_v1_user_logout.py
+++ b/tests/ahriman/web/views/v1/user/test_view_v1_user_logout.py
@@ -5,7 +5,7 @@ from aiohttp.web import HTTPUnauthorized
 from pytest_mock import MockerFixture
 
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v1 import LogoutView
+from ahriman.web.views.v1.user.logout import LogoutView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("POST",):
         request = pytest.helpers.request("", "", method)
         assert await LogoutView.get_permission(request) == UserAccess.Unauthorized
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert LogoutView.ROUTES == ["/api/v1/logout"]
 
 
 async def test_post(client_with_auth: TestClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/v2/status/test_view_v2_status_logs.py
+++ b/tests/ahriman/web/views/v2/status/test_view_v2_status_logs.py
@@ -5,7 +5,7 @@ from aiohttp.test_utils import TestClient
 from ahriman.models.build_status import BuildStatusEnum
 from ahriman.models.package import Package
 from ahriman.models.user_access import UserAccess
-from ahriman.web.views.v2 import LogsView
+from ahriman.web.views.v2.status.logs import LogsView
 
 
 async def test_get_permission() -> None:
@@ -15,6 +15,13 @@ async def test_get_permission() -> None:
     for method in ("GET",):
         request = pytest.helpers.request("", "", method)
         assert await LogsView.get_permission(request) == UserAccess.Reporter
+
+
+def test_routes() -> None:
+    """
+    must return correct routes
+    """
+    assert LogsView.ROUTES == ["/api/v2/packages/{package}/logs"]
 
 
 async def test_get(client: TestClient, package_ahriman: Package) -> None:


### PR DESCRIPTION
## Summary

This mr changes router behavior in the way in which it loads views dynamically. Except for the case in which we can simply do not care about adding new routes, this feature also allows to extend APIs without patching source code

### Checklist

- [x] Tests to cover new code
- [x] `make check` passed
- [x] `make tests` passed
