### PR TITLE
implement local reporter mode

### DIFF
--- a/src/ahriman/application/ahriman.py
+++ b/src/ahriman/application/ahriman.py
@@ -446,7 +446,7 @@ def _set_patch_list_parser(root: SubParserAction) -> argparse.ArgumentParser:
     """
     parser = root.add_parser("patch-list", help="list patch sets",
                              description="list available patches for the package", formatter_class=_formatter)
-    parser.add_argument("package", help="package base", nargs="?")
+    parser.add_argument("package", help="package base")
     parser.add_argument("-e", "--exit-code", help="return non-zero exit status if result is empty", action="store_true")
     parser.add_argument("-v", "--variable", help="if set, show only patches for specified PKGBUILD variables",
                         action="append")

--- a/src/ahriman/application/application/application.py
+++ b/src/ahriman/application/application/application.py
@@ -161,8 +161,7 @@ class Application(ApplicationPackages, ApplicationRepository):
                     package = Package.from_aur(package_name, username)
                 with_dependencies[package.base] = package
 
-                # register package in local database
-                self.database.package_base_update(package)
+                # register package in the database
                 self.repository.reporter.set_unknown(package)
 
         return list(with_dependencies.values())

--- a/src/ahriman/application/application/application_packages.py
+++ b/src/ahriman/application/application/application_packages.py
@@ -65,7 +65,7 @@ class ApplicationPackages(ApplicationProperties):
         """
         package = Package.from_aur(source, username)
         self.database.build_queue_insert(package)
-        self.database.package_base_update(package)
+        self.reporter.set_unknown(package)
 
     def _add_directory(self, source: str, *_: Any) -> None:
         """
@@ -139,7 +139,7 @@ class ApplicationPackages(ApplicationProperties):
         """
         package = Package.from_official(source, self.repository.pacman, username)
         self.database.build_queue_insert(package)
-        self.database.package_base_update(package)
+        self.reporter.set_unknown(package)
 
     def add(self, names: Iterable[str], source: PackageSource, username: str | None = None) -> None:
         """

--- a/src/ahriman/application/application/application_properties.py
+++ b/src/ahriman/application/application/application_properties.py
@@ -21,6 +21,7 @@ from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
 from ahriman.core.log import LazyLogging
 from ahriman.core.repository import Repository
+from ahriman.core.status import Client
 from ahriman.models.pacman_synchronization import PacmanSynchronization
 from ahriman.models.repository_id import RepositoryId
 
@@ -63,3 +64,13 @@ class ApplicationProperties(LazyLogging):
             str: repository architecture
         """
         return self.repository_id.architecture
+
+    @property
+    def reporter(self) -> Client:
+        """
+        instance of the web/database client
+
+        Returns:
+            Client: repository reposter
+        """
+        return self.repository.reporter

--- a/src/ahriman/application/application/application_repository.py
+++ b/src/ahriman/application/application/application_repository.py
@@ -39,15 +39,13 @@ class ApplicationRepository(ApplicationProperties):
         Args:
             packages(Iterable[Package]): list of packages to retrieve changes
         """
-        last_commit_hashes = self.database.hashes_get()
-
         for package in packages:
-            last_commit_sha = last_commit_hashes.get(package.base)
+            last_commit_sha = self.reporter.package_changes_get(package.base).last_commit_sha
             if last_commit_sha is None:
                 continue  # skip check in case if we can't calculate diff
 
             changes = self.repository.package_changes(package, last_commit_sha)
-            self.repository.reporter.package_changes_set(package.base, changes)
+            self.repository.reporter.package_changes_update(package.base, changes)
 
     def clean(self, *, cache: bool, chroot: bool, manual: bool, packages: bool, pacman: bool) -> None:
         """

--- a/src/ahriman/application/handlers/add.py
+++ b/src/ahriman/application/handlers/add.py
@@ -50,7 +50,8 @@ class Add(Handler):
         application.add(args.package, args.source, args.username)
         patches = [PkgbuildPatch.from_env(patch) for patch in args.variable] if args.variable is not None else []
         for package in args.package:  # for each requested package insert patch
-            application.database.patches_insert(package, patches)
+            for patch in patches:
+                application.reporter.package_patches_update(package, patch)
 
         if not args.now:
             return

--- a/src/ahriman/application/handlers/change.py
+++ b/src/ahriman/application/handlers/change.py
@@ -56,4 +56,4 @@ class Change(Handler):
                 ChangesPrinter(changes)(verbose=True, separator="")
                 Change.check_if_empty(args.exit_code, changes.is_empty)
             case Action.Remove:
-                client.package_changes_set(args.package, Changes())
+                client.package_changes_update(args.package, Changes())

--- a/src/ahriman/application/handlers/patch.py
+++ b/src/ahriman/application/handlers/patch.py
@@ -130,12 +130,11 @@ class Patch(Handler):
             variables(list[str] | None): extract patches only for specified PKGBUILD variables
             exit_code(bool): exit with error on empty search result
         """
-        patches = []
-        if variables is not None:
-            for variable in variables:
-                patches.extend(application.reporter.package_patches_get(package_base, variable))
-        else:
-            patches = application.reporter.package_patches_get(package_base, variables)
+        patches = [
+            patch
+            for patch in application.reporter.package_patches_get(package_base, None)
+            if variables is None or patch.key in variables
+        ]
         Patch.check_if_empty(exit_code, not patches)
 
         PatchPrinter(package_base, patches)(verbose=True, separator=" = ")
@@ -154,4 +153,4 @@ class Patch(Handler):
             for variable in variables:  # iterate over single variable
                 application.reporter.package_patches_remove(package_base, variable)
         else:
-            application.reporter.package_patches_remove(package_base, variables)  # just pass as is
+            application.reporter.package_patches_remove(package_base, None)  # just pass as is

--- a/src/ahriman/application/handlers/rebuild.py
+++ b/src/ahriman/application/handlers/rebuild.py
@@ -76,7 +76,7 @@ class Rebuild(Handler):
         if from_database:
             return [
                 package
-                for (package, last_status) in application.database.packages_get()
+                for (package, last_status) in application.reporter.package_get(None)
                 if status is None or last_status.status == status
             ]
 

--- a/src/ahriman/application/handlers/status_update.py
+++ b/src/ahriman/application/handlers/status_update.py
@@ -51,12 +51,8 @@ class StatusUpdate(Handler):
         match args.action:
             case Action.Update if args.package:
                 # update packages statuses
-                packages = application.repository.packages()
-                for base in args.package:
-                    if (local := next((package for package in packages if package.base == base), None)) is not None:
-                        client.package_add(local, args.status)
-                    else:
-                        client.package_update(base, args.status)
+                for package in args.package:
+                    client.package_update(package, args.status)
             case Action.Update:
                 # update service status
                 client.status_update(args.status)

--- a/src/ahriman/application/lock.py
+++ b/src/ahriman/application/lock.py
@@ -27,7 +27,7 @@ from ahriman import __version__
 from ahriman.core.configuration import Configuration
 from ahriman.core.exceptions import DuplicateRunError
 from ahriman.core.log import LazyLogging
-from ahriman.core.status.client import Client
+from ahriman.core.status import Client
 from ahriman.core.util import check_user
 from ahriman.models.build_status import BuildStatusEnum
 from ahriman.models.repository_id import RepositoryId

--- a/src/ahriman/core/build_tools/task.py
+++ b/src/ahriman/core/build_tools/task.py
@@ -21,7 +21,6 @@ from pathlib import Path
 
 from ahriman.core.build_tools.sources import Sources
 from ahriman.core.configuration import Configuration
-from ahriman.core.database import SQLite
 from ahriman.core.exceptions import BuildError
 from ahriman.core.log import LazyLogging
 from ahriman.core.util import check_output
@@ -116,20 +115,20 @@ class Task(LazyLogging):
         # e.g. in some cases packagelist command produces debug packages which were not actually built
         return list(filter(lambda path: path.is_file(), map(Path, packages)))
 
-    def init(self, sources_dir: Path, database: SQLite, local_version: str | None) -> str | None:
+    def init(self, sources_dir: Path, patches: list[PkgbuildPatch], local_version: str | None) -> str | None:
         """
         fetch package from git
 
         Args:
             sources_dir(Path): local path to fetch
-            database(SQLite): database instance
+            patches(list[PkgbuildPatch]): list of patches for the package
             local_version(str | None): local version of the package. If set and equal to current version, it will
                 automatically bump pkgrel
 
         Returns:
             str | None: current commit sha if available
         """
-        last_commit_sha = Sources.load(sources_dir, self.package, database.patches_get(self.package.base), self.paths)
+        last_commit_sha = Sources.load(sources_dir, self.package, patches, self.paths)
         if local_version is None:
             return last_commit_sha  # there is no local package or pkgrel increment is disabled
 

--- a/src/ahriman/core/database/operations/changes_operations.py
+++ b/src/ahriman/core/database/operations/changes_operations.py
@@ -117,27 +117,3 @@ class ChangesOperations(Operations):
                 })
 
         return self.with_connection(run, commit=True)
-
-    def hashes_get(self, repository_id: RepositoryId | None = None) -> dict[str, str]:
-        """
-        extract last commit hashes if available
-
-        Args:
-            repository_id(RepositoryId, optional): repository unique identifier override (Default value = None)
-
-        Returns:
-            dict[str, str]: map of package base to its last commit hash
-        """
-
-        repository_id = repository_id or self._repository_id
-
-        def run(connection: Connection) -> dict[str, str]:
-            return {
-                row["package_base"]: row["last_commit_sha"]
-                for row in connection.execute(
-                    """select package_base, last_commit_sha from package_changes where repository = :repository""",
-                    {"repository": repository_id.id}
-                )
-            }
-
-        return self.with_connection(run)

--- a/src/ahriman/core/database/operations/dependencies_operations.py
+++ b/src/ahriman/core/database/operations/dependencies_operations.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from pathlib import Path
 from sqlite3 import Connection
 
 from ahriman.core.database.operations.operations import Operations
@@ -31,7 +30,7 @@ class DependenciesOperations(Operations):
     """
 
     def dependencies_get(self, package_base: str | None = None,
-                         repository_id: RepositoryId | None = None) -> list[Dependencies]:
+                         repository_id: RepositoryId | None = None) -> dict[str, Dependencies]:
         """
         get dependencies for the specific package base if available
 
@@ -44,15 +43,9 @@ class DependenciesOperations(Operations):
         """
         repository_id = repository_id or self._repository_id
 
-        def run(connection: Connection) -> list[Dependencies]:
-            return [
-                Dependencies(
-                    row["package_base"],
-                    {
-                        Path(path): packages
-                        for path, packages in row["dependencies"].items()
-                    }
-                )
+        def run(connection: Connection) -> dict[str, Dependencies]:
+            return {
+                row["package_base"]: Dependencies(row["dependencies"])
                 for row in connection.execute(
                     """
                         select package_base, dependencies from package_dependencies
@@ -64,15 +57,17 @@ class DependenciesOperations(Operations):
                         "repository": repository_id.id,
                     }
                 )
-            ]
+            }
 
         return self.with_connection(run)
 
-    def dependencies_insert(self, dependencies: Dependencies, repository_id: RepositoryId | None = None) -> None:
+    def dependencies_insert(self, package_base: str, dependencies: Dependencies,
+                            repository_id: RepositoryId | None = None) -> None:
         """
         insert package dependencies
 
         Args:
+            package_base(str): package base
             dependencies(Dependencies): package dependencies
             repository_id(RepositoryId, optional): repository unique identifier override (Default value = None)
         """
@@ -89,12 +84,9 @@ class DependenciesOperations(Operations):
                 dependencies = :dependencies
                 """,
                 {
-                    "package_base": dependencies.package_base,
+                    "package_base": package_base,
                     "repository": repository_id.id,
-                    "dependencies": {
-                        str(path): packages
-                        for path, packages in dependencies.paths.items()
-                    }
+                    "dependencies": dependencies.paths,
                 })
 
         return self.with_connection(run, commit=True)

--- a/src/ahriman/core/database/operations/operations.py
+++ b/src/ahriman/core/database/operations/operations.py
@@ -25,6 +25,7 @@ from typing import Any, TypeVar
 
 from ahriman.core.log import LazyLogging
 from ahriman.models.repository_id import RepositoryId
+from ahriman.models.repository_paths import RepositoryPaths
 
 
 T = TypeVar("T")
@@ -38,7 +39,7 @@ class Operations(LazyLogging):
         path(Path): path to the database file
     """
 
-    def __init__(self, path: Path, repository_id: RepositoryId) -> None:
+    def __init__(self, path: Path, repository_id: RepositoryId, repository_paths: RepositoryPaths) -> None:
         """
         default constructor
 
@@ -48,6 +49,7 @@ class Operations(LazyLogging):
         """
         self.path = path
         self._repository_id = repository_id
+        self._repository_paths = repository_paths
 
     @staticmethod
     def factory(cursor: sqlite3.Cursor, row: tuple[Any, ...]) -> dict[str, Any]:

--- a/src/ahriman/core/database/operations/package_operations.py
+++ b/src/ahriman/core/database/operations/package_operations.py
@@ -218,21 +218,6 @@ class PackageOperations(Operations):
             )
         }
 
-    def package_base_update(self, package: Package, repository_id: RepositoryId | None = None) -> None:
-        """
-        update package base only
-
-        Args:
-            package(Package): package properties
-            repository_id(RepositoryId, optional): repository unique identifier override (Default value = None)
-        """
-        repository_id = repository_id or self._repository_id
-
-        def run(connection: Connection) -> None:
-            self._package_update_insert_base(connection, package, repository_id)
-
-        return self.with_connection(run, commit=True)
-
     def package_remove(self, package_base: str, repository_id: RepositoryId | None = None) -> None:
         """
         remove package from database
@@ -286,26 +271,6 @@ class PackageOperations(Operations):
                 yield package, statuses.get(package_base, BuildStatus())
 
         return self.with_connection(lambda connection: list(run(connection)))
-
-    def remotes_get(self, repository_id: RepositoryId | None = None) -> dict[str, RemoteSource]:
-        """
-        get packages remotes based on current settings
-
-        Args:
-            repository_id(RepositoryId, optional): repository unique identifier override (Default value = None)
-
-        Returns:
-            dict[str, RemoteSource]: map of package base to its remote sources
-        """
-        repository_id = repository_id or self._repository_id
-
-        def run(connection: Connection) -> dict[str, Package]:
-            return self._packages_get_select_package_bases(connection, repository_id)
-
-        return {
-            package_base: package.remote
-            for package_base, package in self.with_connection(run).items()
-        }
 
     def status_update(self, package_base: str, status: BuildStatus, repository_id: RepositoryId | None = None) -> None:
         """

--- a/src/ahriman/core/database/sqlite.py
+++ b/src/ahriman/core/database/sqlite.py
@@ -66,7 +66,7 @@ class SQLite(
         path = cls.database_path(configuration)
         _, repository_id = configuration.check_loaded()
 
-        database = cls(path, repository_id)
+        database = cls(path, repository_id, configuration.repository_paths)
         database.init(configuration)
 
         return database
@@ -119,3 +119,6 @@ class SQLite(
         self.logs_remove(package_base, None)
         self.changes_remove(package_base)
         self.dependencies_remove(package_base)
+
+        # remove local cache too
+        self._repository_paths.tree_clear(package_base)

--- a/src/ahriman/core/gitremote/remote_push_trigger.py
+++ b/src/ahriman/core/gitremote/remote_push_trigger.py
@@ -19,8 +19,8 @@
 #
 from ahriman.core import context
 from ahriman.core.configuration import Configuration
-from ahriman.core.database import SQLite
 from ahriman.core.gitremote.remote_push import RemotePush
+from ahriman.core.status import Client
 from ahriman.core.triggers import Trigger
 from ahriman.models.package import Package
 from ahriman.models.repository_id import RepositoryId
@@ -110,10 +110,10 @@ class RemotePushTrigger(Trigger):
             GitRemoteError: if database is not set in context
         """
         ctx = context.get()
-        database = ctx.get(SQLite)
+        reporter = ctx.get(Client)
 
         for target in self.targets:
             section, _ = self.configuration.gettype(
                 target, self.repository_id, fallback=self.CONFIGURATION_SCHEMA_FALLBACK)
-            runner = RemotePush(database, self.configuration, section)
+            runner = RemotePush(reporter, self.configuration, section)
             runner.run(result)

--- a/src/ahriman/core/log/http_log_handler.py
+++ b/src/ahriman/core/log/http_log_handler.py
@@ -22,6 +22,7 @@ import logging
 from typing import Self
 
 from ahriman.core.configuration import Configuration
+from ahriman.core.status import Client
 from ahriman.models.repository_id import RepositoryId
 
 
@@ -49,8 +50,6 @@ class HttpLogHandler(logging.Handler):
         # we don't really care about those parameters because they will be handled by the reporter
         logging.Handler.__init__(self)
 
-        # client has to be imported here because of circular imports
-        from ahriman.core.status import Client
         self.reporter = Client.load(repository_id, configuration, report=report)
         self.suppress_errors = suppress_errors
 

--- a/src/ahriman/core/log/http_log_handler.py
+++ b/src/ahriman/core/log/http_log_handler.py
@@ -50,7 +50,7 @@ class HttpLogHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         # client has to be imported here because of circular imports
-        from ahriman.core.status.client import Client
+        from ahriman.core.status import Client
         self.reporter = Client.load(repository_id, configuration, report=report)
         self.suppress_errors = suppress_errors
 
@@ -92,7 +92,7 @@ class HttpLogHandler(logging.Handler):
             return  # in case if no package base supplied we need just skip log message
 
         try:
-            self.reporter.package_logs(log_record_id, record)
+            self.reporter.package_logs_add(log_record_id, record.created, record.getMessage())
         except Exception:
             if self.suppress_errors:
                 return

--- a/src/ahriman/core/repository/package_info.py
+++ b/src/ahriman/core/repository/package_info.py
@@ -43,14 +43,15 @@ class PackageInfo(RepositoryProperties):
         Returns:
             list[Package]: list of read packages
         """
+        sources = {package.base: package.remote for package, _, in self.reporter.package_get(None)}
+
         result: dict[str, Package] = {}
         # we are iterating over bases, not single packages
         for full_path in packages:
             try:
                 local = Package.from_archive(full_path, self.pacman)
-                remote, _ = next(iter(self.reporter.package_get(local.base)), (None, None))
-                if remote is not None:  # update source with remote
-                    local.remote = remote.remote
+                if (source := sources.get(local.base)) is not None:  # update source with remote
+                    local.remote = source
 
                 current = result.setdefault(local.base, local)
                 if current.version != local.version:

--- a/src/ahriman/core/repository/repository.py
+++ b/src/ahriman/core/repository/repository.py
@@ -26,6 +26,7 @@ from ahriman.core.database import SQLite
 from ahriman.core.repository.executor import Executor
 from ahriman.core.repository.update_handler import UpdateHandler
 from ahriman.core.sign.gpg import GPG
+from ahriman.core.status import Client
 from ahriman.models.pacman_synchronization import PacmanSynchronization
 from ahriman.models.repository_id import RepositoryId
 
@@ -92,6 +93,7 @@ class Repository(Executor, UpdateHandler):
         ctx.set(Configuration, self.configuration)
         ctx.set(Pacman, self.pacman)
         ctx.set(GPG, self.sign)
+        ctx.set(Client, self.reporter)
 
         ctx.set(type(self), self)
 

--- a/src/ahriman/core/repository/repository_properties.py
+++ b/src/ahriman/core/repository/repository_properties.py
@@ -23,7 +23,7 @@ from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
 from ahriman.core.log import LazyLogging
 from ahriman.core.sign.gpg import GPG
-from ahriman.core.status.client import Client
+from ahriman.core.status import Client
 from ahriman.core.triggers import TriggerLoader
 from ahriman.models.packagers import Packagers
 from ahriman.models.pacman_synchronization import PacmanSynchronization
@@ -75,7 +75,7 @@ class RepositoryProperties(LazyLogging):
         self.pacman = Pacman(repository_id, configuration, refresh_database=refresh_pacman_database)
         self.sign = GPG(configuration)
         self.repo = Repo(self.name, self.paths, self.sign.repository_sign_args)
-        self.reporter = Client.load(repository_id, configuration, report=report)
+        self.reporter = Client.load(repository_id, configuration, database, report=report)
         self.triggers = TriggerLoader.load(repository_id, configuration)
 
     @property

--- a/src/ahriman/core/status/client.py
+++ b/src/ahriman/core/status/client.py
@@ -278,7 +278,7 @@ class Client:
         Args:
             package_base(str): package base to update
         """
-        return self.package_status_update(package_base, BuildStatusEnum.Building)
+        self.package_status_update(package_base, BuildStatusEnum.Building)
 
     def set_failed(self, package_base: str) -> None:
         """
@@ -287,7 +287,7 @@ class Client:
         Args:
             package_base(str): package base to update
         """
-        return self.package_status_update(package_base, BuildStatusEnum.Failed)
+        self.package_status_update(package_base, BuildStatusEnum.Failed)
 
     def set_pending(self, package_base: str) -> None:
         """
@@ -296,7 +296,7 @@ class Client:
         Args:
             package_base(str): package base to update
         """
-        return self.package_status_update(package_base, BuildStatusEnum.Pending)
+        self.package_status_update(package_base, BuildStatusEnum.Pending)
 
     def set_success(self, package: Package) -> None:
         """
@@ -305,16 +305,19 @@ class Client:
         Args:
             package(Package): current package properties
         """
-        return self.package_update(package, BuildStatusEnum.Success)
+        self.package_update(package, BuildStatusEnum.Success)
 
     def set_unknown(self, package: Package) -> None:
         """
-        set package status to unknown
+        set package status to unknown. Unlike other methods, this method also checks if package is known,
+        and - in case if it is - it silently skips updatd
 
         Args:
             package(Package): current package properties
         """
-        return self.package_update(package, BuildStatusEnum.Unknown)
+        if self.package_get(package.base):
+            return  # skip update in case if package is already known
+        self.package_update(package, BuildStatusEnum.Unknown)
 
     def status_get(self) -> InternalStatus:
         """

--- a/src/ahriman/core/status/client.py
+++ b/src/ahriman/core/status/client.py
@@ -79,19 +79,6 @@ class Client:
 
         return make_local_client()
 
-    def package_add(self, package: Package, status: BuildStatusEnum) -> None:
-        """
-        add new package with status
-
-        Args:
-            package(Package): package properties
-            status(BuildStatusEnum): current package build status
-
-        Raises:
-            NotImplementedError: not implemented method
-        """
-        raise NotImplementedError
-
     def package_changes_get(self, package_base: str) -> Changes:
         """
         get package changes
@@ -258,12 +245,25 @@ class Client:
         """
         raise NotImplementedError
 
-    def package_update(self, package_base: str, status: BuildStatusEnum) -> None:
+    def package_status_update(self, package_base: str, status: BuildStatusEnum) -> None:
         """
-        update package build status. Unlike :func:`package_add()` it does not update package properties
+        update package build status. Unlike :func:`package_update()` it does not update package properties
 
         Args:
             package_base(str): package base to update
+            status(BuildStatusEnum): current package build status
+
+        Raises:
+            NotImplementedError: not implemented method
+        """
+        raise NotImplementedError
+
+    def package_update(self, package: Package, status: BuildStatusEnum) -> None:
+        """
+        add new package or update existing one with status
+
+        Args:
+            package(Package): package properties
             status(BuildStatusEnum): current package build status
 
         Raises:
@@ -278,7 +278,7 @@ class Client:
         Args:
             package_base(str): package base to update
         """
-        return self.package_update(package_base, BuildStatusEnum.Building)
+        return self.package_status_update(package_base, BuildStatusEnum.Building)
 
     def set_failed(self, package_base: str) -> None:
         """
@@ -287,7 +287,7 @@ class Client:
         Args:
             package_base(str): package base to update
         """
-        return self.package_update(package_base, BuildStatusEnum.Failed)
+        return self.package_status_update(package_base, BuildStatusEnum.Failed)
 
     def set_pending(self, package_base: str) -> None:
         """
@@ -296,7 +296,7 @@ class Client:
         Args:
             package_base(str): package base to update
         """
-        return self.package_update(package_base, BuildStatusEnum.Pending)
+        return self.package_status_update(package_base, BuildStatusEnum.Pending)
 
     def set_success(self, package: Package) -> None:
         """
@@ -305,7 +305,7 @@ class Client:
         Args:
             package(Package): current package properties
         """
-        return self.package_add(package, BuildStatusEnum.Success)
+        return self.package_update(package, BuildStatusEnum.Success)
 
     def set_unknown(self, package: Package) -> None:
         """
@@ -314,7 +314,7 @@ class Client:
         Args:
             package(Package): current package properties
         """
-        return self.package_add(package, BuildStatusEnum.Unknown)
+        return self.package_update(package, BuildStatusEnum.Unknown)
 
     def status_get(self) -> InternalStatus:
         """

--- a/src/ahriman/core/status/local_client.py
+++ b/src/ahriman/core/status/local_client.py
@@ -48,17 +48,6 @@ class LocalClient(Client):
         self.database = database
         self.repository_id = repository_id
 
-    def package_add(self, package: Package, status: BuildStatusEnum) -> None:
-        """
-        add new package with status
-
-        Args:
-            package(Package): package properties
-            status(BuildStatusEnum): current package build status
-        """
-        self.database.package_update(package, self.repository_id)
-        self.database.status_update(package.base, BuildStatus(status), self.repository_id)
-
     def package_changes_get(self, package_base: str) -> Changes:
         """
         get package changes
@@ -197,12 +186,29 @@ class LocalClient(Client):
         """
         self.database.package_clear(package_base)
 
-    def package_update(self, package_base: str, status: BuildStatusEnum) -> None:
+    def package_status_update(self, package_base: str, status: BuildStatusEnum) -> None:
         """
-        update package build status. Unlike :func:`package_add()` it does not update package properties
+        update package build status. Unlike :func:`package_update()` it does not update package properties
 
         Args:
             package_base(str): package base to update
             status(BuildStatusEnum): current package build status
+
+        Raises:
+            NotImplementedError: not implemented method
         """
         self.database.status_update(package_base, BuildStatus(status), self.repository_id)
+
+    def package_update(self, package: Package, status: BuildStatusEnum) -> None:
+        """
+        add new package or update existing one with status
+
+        Args:
+            package(Package): package properties
+            status(BuildStatusEnum): current package build status
+
+        Raises:
+            NotImplementedError: not implemented method
+        """
+        self.database.package_update(package, self.repository_id)
+        self.database.status_update(package.base, BuildStatus(status), self.repository_id)

--- a/src/ahriman/core/status/local_client.py
+++ b/src/ahriman/core/status/local_client.py
@@ -17,67 +17,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: disable=too-many-public-methods
-from __future__ import annotations
-
-from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
+from ahriman.core.status import Client
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.changes import Changes
 from ahriman.models.dependencies import Dependencies
-from ahriman.models.internal_status import InternalStatus
 from ahriman.models.log_record_id import LogRecordId
 from ahriman.models.package import Package
 from ahriman.models.pkgbuild_patch import PkgbuildPatch
 from ahriman.models.repository_id import RepositoryId
 
 
-class Client:
+class LocalClient(Client):
     """
-    base build status reporter client
+    local database handler
+
+    Attributes:
+        database(SQLite): database instance
+        repository_id(RepositoryId): repository unique identifier
     """
 
-    @staticmethod
-    def load(repository_id: RepositoryId, configuration: Configuration, database: SQLite | None = None, *,
-             report: bool = True) -> Client:
+    def __init__(self, repository_id: RepositoryId, database: SQLite) -> None:
         """
-        load client from settings
+        default constructor
 
         Args:
             repository_id(RepositoryId): repository unique identifier
-            configuration(Configuration): configuration instance
-            database(SQLite | None, optional): database instance (Default value = None)
-            report(bool, optional): force enable or disable reporting (Default value = True)
-
-        Returns:
-            Client: client according to current settings
+            database(SQLite): database instance:
         """
-        def make_local_client() -> Client:
-            if database is None:
-                return Client()
-
-            from ahriman.core.status.local_client import LocalClient
-            return LocalClient(repository_id, database)
-
-        if not report:
-            return make_local_client()
-        if not configuration.getboolean("status", "enabled", fallback=True):  # global switch
-            return make_local_client()
-
-        # new-style section
-        address = configuration.get("status", "address", fallback=None)
-        # old-style section
-        legacy_address = configuration.get("web", "address", fallback=None)
-        host = configuration.get("web", "host", fallback=None)
-        port = configuration.getint("web", "port", fallback=None)
-        socket = configuration.get("web", "unix_socket", fallback=None)
-
-        # basically we just check if there is something we can use for interaction with remote server
-        if address or legacy_address or (host and port) or socket:
-            from ahriman.core.status.web_client import WebClient
-            return WebClient(repository_id, configuration)
-
-        return make_local_client()
+        self.database = database
+        self.repository_id = repository_id
 
     def package_add(self, package: Package, status: BuildStatusEnum) -> None:
         """
@@ -86,11 +55,9 @@ class Client:
         Args:
             package(Package): package properties
             status(BuildStatusEnum): current package build status
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        self.database.package_update(package, self.repository_id)
+        self.database.status_update(package.base, BuildStatus(status), self.repository_id)
 
     def package_changes_get(self, package_base: str) -> Changes:
         """
@@ -101,11 +68,8 @@ class Client:
 
         Returns:
             Changes: package changes if available and empty object otherwise
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        return self.database.changes_get(package_base, self.repository_id)
 
     def package_changes_update(self, package_base: str, changes: Changes) -> None:
         """
@@ -114,11 +78,8 @@ class Client:
         Args:
             package_base(str): package base to update
             changes(Changes): changes descriptor
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        self.database.changes_insert(package_base, changes, self.repository_id)
 
     def package_dependencies_get(self, package_base: str) -> Dependencies:
         """
@@ -129,11 +90,8 @@ class Client:
 
         Returns:
             list[Dependencies]: package implicit dependencies if available
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        return self.database.dependencies_get(package_base, self.repository_id).get(package_base, Dependencies())
 
     def package_dependencies_update(self, package_base: str, dependencies: Dependencies) -> None:
         """
@@ -142,11 +100,8 @@ class Client:
         Args:
             package_base(str): package base to update
             dependencies(Dependencies): dependencies descriptor
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        self.database.dependencies_insert(package_base, dependencies, self.repository_id)
 
     def package_get(self, package_base: str | None) -> list[tuple[Package, BuildStatus]]:
         """
@@ -157,11 +112,11 @@ class Client:
 
         Returns:
             list[tuple[Package, BuildStatus]]: list of current package description and status if it has been found
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        packages = self.database.packages_get(self.repository_id)
+        if package_base is None:
+            return packages
+        return [(package, status) for package, status in packages if package.base == package_base]
 
     def package_logs_add(self, log_record_id: LogRecordId, created: float, message: str) -> None:
         """
@@ -172,7 +127,7 @@ class Client:
             created(float): log created timestamp
             message(str): log message
         """
-        # this method does not raise NotImplementedError because it is actively used as dummy client for http log
+        self.database.logs_insert(log_record_id, created, message, self.repository_id)
 
     def package_logs_get(self, package_base: str, limit: int = -1, offset: int = 0) -> list[tuple[float, str]]:
         """
@@ -185,11 +140,8 @@ class Client:
 
         Returns:
             list[tuple[float, str]]: package logs
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        return self.database.logs_get(package_base, limit, offset, self.repository_id)
 
     def package_logs_remove(self, package_base: str, version: str | None) -> None:
         """
@@ -198,11 +150,8 @@ class Client:
         Args:
             package_base(str): package base
             version(str | None): package version to remove logs. If None set, all logs will be removed
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        self.database.logs_remove(package_base, version, self.repository_id)
 
     def package_patches_get(self, package_base: str, variable: str | None) -> list[PkgbuildPatch]:
         """
@@ -214,11 +163,9 @@ class Client:
 
         Returns:
             list[PkgbuildPatch]: list of patches for the specified package
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        variables = [variable] if variable is not None else None
+        return self.database.patches_list(package_base, variables).get(package_base, [])
 
     def package_patches_remove(self, package_base: str, variable: str | None) -> None:
         """
@@ -227,11 +174,9 @@ class Client:
         Args:
             package_base(str): package base to update
             variable(str | None): patch name. If None set, all patches will be removed
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        variables = [variable] if variable is not None else None
+        self.database.patches_remove(package_base, variables)
 
     def package_patches_update(self, package_base: str, patch: PkgbuildPatch) -> None:
         """
@@ -240,11 +185,8 @@ class Client:
         Args:
             package_base(str): package base to update
             patch(PkgbuildPatch): package patch
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        self.database.patches_insert(package_base, [patch])
 
     def package_remove(self, package_base: str) -> None:
         """
@@ -252,11 +194,8 @@ class Client:
 
         Args:
             package_base(str): package base to remove
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
+        self.database.package_clear(package_base)
 
     def package_update(self, package_base: str, status: BuildStatusEnum) -> None:
         """
@@ -265,70 +204,5 @@ class Client:
         Args:
             package_base(str): package base to update
             status(BuildStatusEnum): current package build status
-
-        Raises:
-            NotImplementedError: not implemented method
         """
-        raise NotImplementedError
-
-    def set_building(self, package_base: str) -> None:
-        """
-        set package status to building
-
-        Args:
-            package_base(str): package base to update
-        """
-        return self.package_update(package_base, BuildStatusEnum.Building)
-
-    def set_failed(self, package_base: str) -> None:
-        """
-        set package status to failed
-
-        Args:
-            package_base(str): package base to update
-        """
-        return self.package_update(package_base, BuildStatusEnum.Failed)
-
-    def set_pending(self, package_base: str) -> None:
-        """
-        set package status to pending
-
-        Args:
-            package_base(str): package base to update
-        """
-        return self.package_update(package_base, BuildStatusEnum.Pending)
-
-    def set_success(self, package: Package) -> None:
-        """
-        set package status to success
-
-        Args:
-            package(Package): current package properties
-        """
-        return self.package_add(package, BuildStatusEnum.Success)
-
-    def set_unknown(self, package: Package) -> None:
-        """
-        set package status to unknown
-
-        Args:
-            package(Package): current package properties
-        """
-        return self.package_add(package, BuildStatusEnum.Unknown)
-
-    def status_get(self) -> InternalStatus:
-        """
-        get internal service status
-
-        Returns:
-            InternalStatus: current internal (web) service status
-        """
-        return InternalStatus(status=BuildStatus())
-
-    def status_update(self, status: BuildStatusEnum) -> None:
-        """
-        update ahriman status itself
-
-        Args:
-            status(BuildStatusEnum): current ahriman status
-        """
+        self.database.status_update(package_base, BuildStatus(status), self.repository_id)

--- a/src/ahriman/core/status/watcher.py
+++ b/src/ahriman/core/status/watcher.py
@@ -78,18 +78,6 @@ class Watcher(LazyLogging):
                 for package, status in self.client.package_get(None)
             }
 
-    def package_add(self, package: Package, status: BuildStatusEnum) -> None:
-        """
-        update package
-
-        Args:
-            package(Package): package description
-            status(BuildStatusEnum): new build status
-        """
-        with self._lock:
-            self._known[package.base] = (package, BuildStatus(status))
-        self.client.package_add(package, status)
-
     package_changes_get: Callable[[str], Changes]
 
     package_changes_update: Callable[[str, Changes], None]
@@ -154,7 +142,7 @@ class Watcher(LazyLogging):
         self.client.package_remove(package_base)
         self.package_logs_remove(package_base, None)
 
-    def package_update(self, package_base: str, status: BuildStatusEnum) -> None:
+    def package_status_update(self, package_base: str, status: BuildStatusEnum) -> None:
         """
         update package status
 
@@ -165,7 +153,19 @@ class Watcher(LazyLogging):
         package, _ = self.package_get(package_base)
         with self._lock:
             self._known[package_base] = (package, BuildStatus(status))
-        self.client.package_update(package_base, status)
+        self.client.package_status_update(package_base, status)
+
+    def package_update(self, package: Package, status: BuildStatusEnum) -> None:
+        """
+        update package
+
+        Args:
+            package(Package): package description
+            status(BuildStatusEnum): new build status
+        """
+        with self._lock:
+            self._known[package.base] = (package, BuildStatus(status))
+        self.client.package_update(package, status)
 
     def status_update(self, status: BuildStatusEnum) -> None:
         """

--- a/src/ahriman/core/status/web_client.py
+++ b/src/ahriman/core/status/web_client.py
@@ -157,22 +157,6 @@ class WebClient(Client, SyncAhrimanClient):
         """
         return f"{self.address}/api/v1/status"
 
-    def package_add(self, package: Package, status: BuildStatusEnum) -> None:
-        """
-        add new package with status
-
-        Args:
-            package(Package): package properties
-            status(BuildStatusEnum): current package build status
-        """
-        payload = {
-            "status": status.value,
-            "package": package.view()
-        }
-        with contextlib.suppress(Exception):
-            self.make_request("POST", self._package_url(package.base),
-                              params=self.repository_id.query(), json=payload)
-
     def package_changes_get(self, package_base: str) -> Changes:
         """
         get package changes
@@ -365,17 +349,39 @@ class WebClient(Client, SyncAhrimanClient):
         with contextlib.suppress(Exception):
             self.make_request("DELETE", self._package_url(package_base), params=self.repository_id.query())
 
-    def package_update(self, package_base: str, status: BuildStatusEnum) -> None:
+    def package_status_update(self, package_base: str, status: BuildStatusEnum) -> None:
         """
-        update package build status. Unlike :func:`package_add()` it does not update package properties
+        update package build status. Unlike :func:`package_update()` it does not update package properties
 
         Args:
             package_base(str): package base to update
             status(BuildStatusEnum): current package build status
+
+        Raises:
+            NotImplementedError: not implemented method
         """
         payload = {"status": status.value}
         with contextlib.suppress(Exception):
             self.make_request("POST", self._package_url(package_base),
+                              params=self.repository_id.query(), json=payload)
+
+    def package_update(self, package: Package, status: BuildStatusEnum) -> None:
+        """
+        add new package or update existing one with status
+
+        Args:
+            package(Package): package properties
+            status(BuildStatusEnum): current package build status
+
+        Raises:
+            NotImplementedError: not implemented method
+        """
+        payload = {
+            "status": status.value,
+            "package": package.view(),
+        }
+        with contextlib.suppress(Exception):
+            self.make_request("POST", self._package_url(package.base),
                               params=self.repository_id.query(), json=payload)
 
     def status_get(self) -> InternalStatus:

--- a/src/ahriman/core/status/web_client.py
+++ b/src/ahriman/core/status/web_client.py
@@ -18,18 +18,19 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import contextlib
-import logging
 
 from urllib.parse import quote_plus as urlencode
 
 from ahriman.core.configuration import Configuration
 from ahriman.core.http import SyncAhrimanClient
-from ahriman.core.status.client import Client
+from ahriman.core.status import Client
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.changes import Changes
+from ahriman.models.dependencies import Dependencies
 from ahriman.models.internal_status import InternalStatus
 from ahriman.models.log_record_id import LogRecordId
 from ahriman.models.package import Package
+from ahriman.models.pkgbuild_patch import PkgbuildPatch
 from ahriman.models.repository_id import RepositoryId
 
 
@@ -92,9 +93,21 @@ class WebClient(Client, SyncAhrimanClient):
             package_base(str): package base
 
         Returns:
-            str: full url for web service for logs
+            str: full url for web service for changes
         """
         return f"{self.address}/api/v1/packages/{urlencode(package_base)}/changes"
+
+    def _dependencies_url(self, package_base: str) -> str:
+        """
+        get url for the dependencies api
+
+        Args:
+            package_base(str): package base
+
+        Returns:
+            str: full url for web service for dependencies
+        """
+        return f"{self.address}/api/v1/packages/{urlencode(package_base)}/dependencies"
 
     def _logs_url(self, package_base: str) -> str:
         """
@@ -110,7 +123,7 @@ class WebClient(Client, SyncAhrimanClient):
 
     def _package_url(self, package_base: str = "") -> str:
         """
-        url generator
+        package url generator
 
         Args:
             package_base(str, optional): package base to generate url (Default value = "")
@@ -120,6 +133,20 @@ class WebClient(Client, SyncAhrimanClient):
         """
         suffix = f"/{urlencode(package_base)}" if package_base else ""
         return f"{self.address}/api/v1/packages{suffix}"
+
+    def _patches_url(self, package_base: str, variable: str = "") -> str:
+        """
+        patches url generator
+
+        Args:
+            package_base(str): package base
+            variable(str, optional): patch variable name to generate url (Default value = "")
+
+        Returns:
+            str: full url of web service for the package patch
+        """
+        suffix = f"/{urlencode(variable)}" if variable else ""
+        return f"{self.address}/api/v1/packages/{urlencode(package_base)}/patches{suffix}"
 
     def _status_url(self) -> str:
         """
@@ -165,7 +192,7 @@ class WebClient(Client, SyncAhrimanClient):
 
         return Changes()
 
-    def package_changes_set(self, package_base: str, changes: Changes) -> None:
+    def package_changes_update(self, package_base: str, changes: Changes) -> None:
         """
         update package changes
 
@@ -176,6 +203,37 @@ class WebClient(Client, SyncAhrimanClient):
         with contextlib.suppress(Exception):
             self.make_request("POST", self._changes_url(package_base),
                               params=self.repository_id.query(), json=changes.view())
+
+    def package_dependencies_get(self, package_base: str) -> Dependencies:
+        """
+        get package dependencies
+
+        Args:
+            package_base(str): package base to retrieve
+
+        Returns:
+            list[Dependencies]: package implicit dependencies if available
+        """
+        with contextlib.suppress(Exception):
+            response = self.make_request("GET", self._dependencies_url(package_base),
+                                         params=self.repository_id.query())
+            response_json = response.json()
+
+            return Dependencies.from_json(response_json)
+
+        return Dependencies()
+
+    def package_dependencies_update(self, package_base: str, dependencies: Dependencies) -> None:
+        """
+        update package dependencies
+
+        Args:
+            package_base(str): package base to update
+            dependencies(Dependencies): dependencies descriptor
+        """
+        with contextlib.suppress(Exception):
+            self.make_request("POST", self._dependencies_url(package_base),
+                              params=self.repository_id.query(), json=dependencies.view())
 
     def package_get(self, package_base: str | None) -> list[tuple[Package, BuildStatus]]:
         """
@@ -199,17 +257,18 @@ class WebClient(Client, SyncAhrimanClient):
 
         return []
 
-    def package_logs(self, log_record_id: LogRecordId, record: logging.LogRecord) -> None:
+    def package_logs_add(self, log_record_id: LogRecordId, created: float, message: str) -> None:
         """
         post log record
 
         Args:
             log_record_id(LogRecordId): log record id
-            record(logging.LogRecord): log record to post to api
+            created(float): log created timestamp
+            message(str): log message
         """
         payload = {
-            "created": record.created,
-            "message": record.getMessage(),
+            "created": created,
+            "message": message,
             "version": log_record_id.version,
         }
 
@@ -218,6 +277,83 @@ class WebClient(Client, SyncAhrimanClient):
         # In the other hand, we force to suppress all http logs here to avoid cyclic reporting
         self.make_request("POST", self._logs_url(log_record_id.package_base),
                           params=self.repository_id.query(), json=payload, suppress_errors=True)
+
+    def package_logs_get(self, package_base: str, limit: int = -1, offset: int = 0) -> list[tuple[float, str]]:
+        """
+        get package logs
+
+        Args:
+            package_base(str): package base
+            limit(int, optional): limit records to the specified count, -1 means unlimited (Default value = -1)
+            offset(int, optional): records offset (Default value = 0)
+
+        Returns:
+            list[tuple[float, str]]: package logs
+        """
+        with contextlib.suppress(Exception):
+            query = self.repository_id.query() + [("limit", str(limit)), ("offset", str(offset))]
+            response = self.make_request("GET", self._logs_url(package_base), params=query)
+            response_json = response.json()
+
+            return [(record["created"], record["message"]) for record in response_json]
+
+        return []
+
+    def package_logs_remove(self, package_base: str, version: str | None) -> None:
+        """
+        remove package logs
+
+        Args:
+            package_base(str): package base
+            version(str | None): package version to remove logs. If None set, all logs will be removed
+        """
+        with contextlib.suppress(Exception):
+            query = self.repository_id.query()
+            if version is not None:
+                query += [("version", version)]
+            self.make_request("DELETE", self._logs_url(package_base), params=query)
+
+    def package_patches_get(self, package_base: str, variable: str | None) -> list[PkgbuildPatch]:
+        """
+        get package patches
+
+        Args:
+            package_base(str): package base to retrieve
+            variable(str | None): optional filter by patch variable
+
+        Returns:
+            list[PkgbuildPatch]: list of patches for the specified package
+        """
+        with contextlib.suppress(Exception):
+            response = self.make_request("GET", self._patches_url(package_base, variable or ""))
+            response_json = response.json()
+
+            patches = response_json if variable is None else [response_json]
+            return [PkgbuildPatch.from_json(patch) for patch in patches]
+
+        return []
+
+    def package_patches_remove(self, package_base: str, variable: str | None) -> None:
+        """
+        remove package patch
+
+        Args:
+            package_base(str): package base to update
+            variable(str | None): patch name. If None set, all patches will be removed
+        """
+        with contextlib.suppress(Exception):
+            self.make_request("DELETE", self._patches_url(package_base, variable or ""))
+
+    def package_patches_update(self, package_base: str, patch: PkgbuildPatch) -> None:
+        """
+        create or update package patch
+
+        Args:
+            package_base(str): package base to update
+            patch(PkgbuildPatch): package patch
+        """
+        with contextlib.suppress(Exception):
+            self.make_request("POST", self._patches_url(package_base), json=patch.view())
 
     def package_remove(self, package_base: str) -> None:
         """

--- a/src/ahriman/models/dependencies.py
+++ b/src/ahriman/models/dependencies.py
@@ -17,8 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass, field, fields
+from typing import Any, Self
+
+from ahriman.core.util import dataclass_view, filter_json
 
 
 @dataclass(frozen=True)
@@ -27,9 +29,31 @@ class Dependencies:
     package paths dependencies
 
     Attributes:
-        package_base(str): package base
-        paths(dict[Path, list[str]]): map of the paths used by this package to set of packages in which they were found
+        paths(dict[str, list[str]]): map of the paths used by this package to set of packages in which they were found
     """
 
-    package_base: str
-    paths: dict[Path, list[str]] = field(default_factory=dict)
+    paths: dict[str, list[str]] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, dump: dict[str, Any]) -> Self:
+        """
+        construct dependencies from the json dump
+
+        Args:
+            dump(dict[str, Any]): json dump body
+
+        Returns:
+            Self: dependencies object
+        """
+        # filter to only known fields
+        known_fields = [pair.name for pair in fields(cls)]
+        return cls(**filter_json(dump, known_fields))
+
+    def view(self) -> dict[str, Any]:
+        """
+        generate json dependencies view
+
+        Returns:
+            dict[str, Any]: json-friendly dictionary
+        """
+        return dataclass_view(self)

--- a/src/ahriman/models/package_archive.py
+++ b/src/ahriman/models/package_archive.py
@@ -99,7 +99,7 @@ class PackageArchive:
         """
         dependencies, roots = self.depends_on_paths()
 
-        result: dict[Path, list[str]] = {}
+        result: dict[str, list[str]] = {}
         for package, (directories, files) in self.installed_packages().items():
             if package in self.package.packages:
                 continue  # skip package itself
@@ -108,9 +108,9 @@ class PackageArchive:
             required_by.extend(library for library in files if library.name in dependencies)
 
             for path in required_by:
-                result.setdefault(path, []).append(package)
+                result.setdefault(str(path), []).append(package)
 
-        return Dependencies(self.package.base, result)
+        return Dependencies(result)
 
     def depends_on_paths(self) -> tuple[set[str], set[Path]]:
         """

--- a/src/ahriman/models/pkgbuild_patch.py
+++ b/src/ahriman/models/pkgbuild_patch.py
@@ -19,11 +19,11 @@
 #
 import shlex
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Generator, Self
 
-from ahriman.core.util import dataclass_view
+from ahriman.core.util import dataclass_view, filter_json
 
 
 @dataclass(frozen=True)
@@ -83,6 +83,21 @@ class PkgbuildPatch:
         key, *value_parts = variable.split("=", maxsplit=1)
         raw_value = next(iter(value_parts), "")  # extract raw value
         return cls(key, cls.parse(raw_value))
+
+    @classmethod
+    def from_json(cls, dump: dict[str, Any]) -> Self:
+        """
+        construct patch descriptor from the json dump
+
+        Args:
+            dump(dict[str, Any]): json dump body
+
+        Returns:
+            Self: patch object
+        """
+        # filter to only known fields
+        known_fields = [pair.name for pair in fields(cls)]
+        return cls(**filter_json(dump, known_fields))
 
     @staticmethod
     def parse(source: str) -> str | list[str]:

--- a/src/ahriman/web/schemas/__init__.py
+++ b/src/ahriman/web/schemas/__init__.py
@@ -22,6 +22,7 @@ from ahriman.web.schemas.auth_schema import AuthSchema
 from ahriman.web.schemas.build_options_schema import BuildOptionsSchema
 from ahriman.web.schemas.changes_schema import ChangesSchema
 from ahriman.web.schemas.counters_schema import CountersSchema
+from ahriman.web.schemas.dependencies_schema import DependenciesSchema
 from ahriman.web.schemas.error_schema import ErrorSchema
 from ahriman.web.schemas.file_schema import FileSchema
 from ahriman.web.schemas.info_schema import InfoSchema
@@ -36,6 +37,7 @@ from ahriman.web.schemas.package_patch_schema import PackagePatchSchema
 from ahriman.web.schemas.package_properties_schema import PackagePropertiesSchema
 from ahriman.web.schemas.package_schema import PackageSchema
 from ahriman.web.schemas.package_status_schema import PackageStatusSchema, PackageStatusSimplifiedSchema
+from ahriman.web.schemas.package_version_schema import PackageVersionSchema
 from ahriman.web.schemas.pagination_schema import PaginationSchema
 from ahriman.web.schemas.patch_name_schema import PatchNameSchema
 from ahriman.web.schemas.patch_schema import PatchSchema

--- a/src/ahriman/web/schemas/dependencies_schema.py
+++ b/src/ahriman/web/schemas/dependencies_schema.py
@@ -17,4 +17,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from ahriman.core.status.client import Client
+from marshmallow import Schema, fields
+
+
+class DependenciesSchema(Schema):
+    """
+    request/response package dependencies schema
+    """
+
+    paths = fields.Dict(
+        keys=fields.String(), values=fields.List(fields.String()), required=True, metadata={
+            "description": "Map of filesystem paths to packages which contain this path",
+        })

--- a/src/ahriman/web/schemas/package_version_schema.py
+++ b/src/ahriman/web/schemas/package_version_schema.py
@@ -17,4 +17,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from ahriman.core.status.client import Client
+from marshmallow import fields
+
+from ahriman import __version__
+from ahriman.web.schemas.repository_id_schema import RepositoryIdSchema
+
+
+class PackageVersionSchema(RepositoryIdSchema):
+    """
+    request package name schema
+    """
+
+    version = fields.String(metadata={
+        "description": "Package version",
+        "example": __version__,
+    })

--- a/src/ahriman/web/schemas/patch_schema.py
+++ b/src/ahriman/web/schemas/patch_schema.py
@@ -25,8 +25,8 @@ class PatchSchema(Schema):
     request and response patch schema
     """
 
-    key = fields.String(required=True, metadata={
-        "description": "environment variable name",
+    key = fields.String(metadata={
+        "description": "environment variable name. Required in case if it is not full diff",
     })
     value = fields.String(metadata={
         "description": "environment variable value",

--- a/src/ahriman/web/views/base.py
+++ b/src/ahriman/web/views/base.py
@@ -25,6 +25,7 @@ from typing import TypeVar
 from ahriman.core.auth import Auth
 from ahriman.core.configuration import Configuration
 from ahriman.core.distributed import WorkersCache
+from ahriman.core.exceptions import UnknownPackageError
 from ahriman.core.sign.gpg import GPG
 from ahriman.core.spawn import Spawn
 from ahriman.core.status.watcher import Watcher
@@ -238,6 +239,8 @@ class BaseView(View, CorsViewMixin):
             return self.services[repository_id](package_base)
         except KeyError:
             raise HTTPNotFound(reason=f"Repository {repository_id.id} is unknown")
+        except UnknownPackageError:
+            raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 
     async def username(self) -> str | None:
         """

--- a/src/ahriman/web/views/base.py
+++ b/src/ahriman/web/views/base.py
@@ -218,12 +218,13 @@ class BaseView(View, CorsViewMixin):
             return RepositoryId(architecture, name)
         return next(iter(sorted(self.services.keys())))
 
-    def service(self, repository_id: RepositoryId | None = None) -> Watcher:
+    def service(self, repository_id: RepositoryId | None = None, package_base: str | None = None) -> Watcher:
         """
         get status watcher instance
 
         Args:
             repository_id(RepositoryId | None, optional): repository unique identifier (Default value = None)
+            package_base(str | None, optional): package base to validate if exists (Default value = None)
 
         Returns:
             Watcher: build status watcher instance. If no repository provided, it will return the first one
@@ -234,7 +235,7 @@ class BaseView(View, CorsViewMixin):
         if repository_id is None:
             repository_id = self.repository_id()
         try:
-            return self.services[repository_id]
+            return self.services[repository_id](package_base)
         except KeyError:
             raise HTTPNotFound(reason=f"Repository {repository_id.id} is unknown")
 

--- a/src/ahriman/web/views/v1/packages/changes.py
+++ b/src/ahriman/web/views/v1/packages/changes.py
@@ -71,7 +71,7 @@ class ChangesView(StatusViewGuard, BaseView):
         package_base = self.request.match_info["package"]
 
         try:
-            changes = self.service().package_changes_get(package_base)
+            changes = self.service(package_base=package_base).package_changes_get(package_base)
         except UnknownPackageError:
             raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 
@@ -86,7 +86,7 @@ class ChangesView(StatusViewGuard, BaseView):
             400: {"description": "Bad data is supplied", "schema": ErrorSchema},
             401: {"description": "Authorization required", "schema": ErrorSchema},
             403: {"description": "Access is forbidden", "schema": ErrorSchema},
-            404: {"description": "Package base and/or repository are unknown", "schema": ErrorSchema},
+            404: {"description": "Repository is unknown", "schema": ErrorSchema},
             500: {"description": "Internal server error", "schema": ErrorSchema},
         },
         security=[{"token": [POST_PERMISSION]}],
@@ -113,9 +113,6 @@ class ChangesView(StatusViewGuard, BaseView):
             raise HTTPBadRequest(reason=str(ex))
 
         changes = Changes(last_commit_sha, change)
-        try:
-            self.service().package_changes_update(package_base, changes)
-        except UnknownPackageError:
-            raise HTTPNotFound(reason=f"Package {package_base} is unknown")
+        self.service().package_changes_update(package_base, changes)
 
         raise HTTPNoContent

--- a/src/ahriman/web/views/v1/packages/changes.py
+++ b/src/ahriman/web/views/v1/packages/changes.py
@@ -86,7 +86,7 @@ class ChangesView(StatusViewGuard, BaseView):
             400: {"description": "Bad data is supplied", "schema": ErrorSchema},
             401: {"description": "Authorization required", "schema": ErrorSchema},
             403: {"description": "Access is forbidden", "schema": ErrorSchema},
-            404: {"description": "Repository is unknown", "schema": ErrorSchema},
+            404: {"description": "Package base and/or repository are unknown", "schema": ErrorSchema},
             500: {"description": "Internal server error", "schema": ErrorSchema},
         },
         security=[{"token": [POST_PERMISSION]}],
@@ -113,7 +113,9 @@ class ChangesView(StatusViewGuard, BaseView):
             raise HTTPBadRequest(reason=str(ex))
 
         changes = Changes(last_commit_sha, change)
-        repository_id = self.repository_id()
-        self.service(repository_id).database.changes_insert(package_base, changes, repository_id)
+        try:
+            self.service().package_changes_update(package_base, changes)
+        except UnknownPackageError:
+            raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 
         raise HTTPNoContent

--- a/src/ahriman/web/views/v1/packages/changes.py
+++ b/src/ahriman/web/views/v1/packages/changes.py
@@ -19,9 +19,8 @@
 #
 import aiohttp_apispec  # type: ignore[import-untyped]
 
-from aiohttp.web import HTTPBadRequest, HTTPNoContent, HTTPNotFound, Response, json_response
+from aiohttp.web import HTTPBadRequest, HTTPNoContent, Response, json_response
 
-from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.changes import Changes
 from ahriman.models.user_access import UserAccess
 from ahriman.web.schemas import AuthSchema, ChangesSchema, ErrorSchema, PackageNameSchema, RepositoryIdSchema
@@ -70,10 +69,7 @@ class ChangesView(StatusViewGuard, BaseView):
         """
         package_base = self.request.match_info["package"]
 
-        try:
-            changes = self.service(package_base=package_base).package_changes_get(package_base)
-        except UnknownPackageError:
-            raise HTTPNotFound(reason=f"Package {package_base} is unknown")
+        changes = self.service(package_base=package_base).package_changes_get(package_base)
 
         return json_response(changes.view())
 

--- a/src/ahriman/web/views/v1/packages/dependencies.py
+++ b/src/ahriman/web/views/v1/packages/dependencies.py
@@ -19,9 +19,8 @@
 #
 import aiohttp_apispec  # type: ignore[import-untyped]
 
-from aiohttp.web import HTTPBadRequest, HTTPNoContent, HTTPNotFound, Response, json_response
+from aiohttp.web import HTTPBadRequest, HTTPNoContent, Response, json_response
 
-from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.dependencies import Dependencies
 from ahriman.models.user_access import UserAccess
 from ahriman.web.schemas import AuthSchema, DependenciesSchema, ErrorSchema, PackageNameSchema, RepositoryIdSchema
@@ -70,10 +69,7 @@ class DependenciesView(StatusViewGuard, BaseView):
         """
         package_base = self.request.match_info["package"]
 
-        try:
-            dependencies = self.service(package_base=package_base).package_dependencies_get(package_base)
-        except UnknownPackageError:
-            raise HTTPNotFound(reason=f"Package {package_base} is unknown")
+        dependencies = self.service(package_base=package_base).package_dependencies_get(package_base)
 
         return json_response(dependencies.view())
 
@@ -112,9 +108,6 @@ class DependenciesView(StatusViewGuard, BaseView):
         except Exception as ex:
             raise HTTPBadRequest(reason=str(ex))
 
-        try:
-            self.service(package_base=package_base).package_dependencies_update(package_base, dependencies)
-        except UnknownPackageError:
-            raise HTTPNotFound(reason=f"Package {package_base} is unknown")
+        self.service(package_base=package_base).package_dependencies_update(package_base, dependencies)
 
         raise HTTPNoContent

--- a/src/ahriman/web/views/v1/packages/dependencies.py
+++ b/src/ahriman/web/views/v1/packages/dependencies.py
@@ -71,7 +71,7 @@ class DependenciesView(StatusViewGuard, BaseView):
         package_base = self.request.match_info["package"]
 
         try:
-            dependencies = self.service().package_dependencies_get(package_base)
+            dependencies = self.service(package_base=package_base).package_dependencies_get(package_base)
         except UnknownPackageError:
             raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 
@@ -113,7 +113,7 @@ class DependenciesView(StatusViewGuard, BaseView):
             raise HTTPBadRequest(reason=str(ex))
 
         try:
-            self.service().package_dependencies_update(package_base, dependencies)
+            self.service(package_base=package_base).package_dependencies_update(package_base, dependencies)
         except UnknownPackageError:
             raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 

--- a/src/ahriman/web/views/v1/packages/logs.py
+++ b/src/ahriman/web/views/v1/packages/logs.py
@@ -104,7 +104,7 @@ class LogsView(StatusViewGuard, BaseView):
 
         try:
             _, status = self.service().package_get(package_base)
-            logs = self.service().package_logs_get(package_base)
+            logs = self.service(package_base=package_base).package_logs_get(package_base, -1, 0)
         except UnknownPackageError:
             raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 
@@ -150,6 +150,6 @@ class LogsView(StatusViewGuard, BaseView):
         except Exception as ex:
             raise HTTPBadRequest(reason=str(ex))
 
-        self.service().package_logs_update(LogRecordId(package_base, version), created, record)
+        self.service().package_logs_add(LogRecordId(package_base, version), created, record)
 
         raise HTTPNoContent

--- a/src/ahriman/web/views/v1/packages/logs.py
+++ b/src/ahriman/web/views/v1/packages/logs.py
@@ -25,8 +25,8 @@ from ahriman.core.exceptions import UnknownPackageError
 from ahriman.core.util import pretty_datetime
 from ahriman.models.log_record_id import LogRecordId
 from ahriman.models.user_access import UserAccess
-from ahriman.web.schemas import AuthSchema, ErrorSchema, LogsSchema, PackageNameSchema, RepositoryIdSchema, \
-    VersionedLogSchema
+from ahriman.web.schemas import AuthSchema, ErrorSchema, LogsSchema, PackageNameSchema, PackageVersionSchema, \
+    RepositoryIdSchema, VersionedLogSchema
 from ahriman.web.views.base import BaseView
 from ahriman.web.views.status_view_guard import StatusViewGuard
 
@@ -60,7 +60,7 @@ class LogsView(StatusViewGuard, BaseView):
     )
     @aiohttp_apispec.cookies_schema(AuthSchema)
     @aiohttp_apispec.match_info_schema(PackageNameSchema)
-    @aiohttp_apispec.querystring_schema(RepositoryIdSchema)
+    @aiohttp_apispec.querystring_schema(PackageVersionSchema)
     async def delete(self) -> None:
         """
         delete package logs
@@ -69,7 +69,8 @@ class LogsView(StatusViewGuard, BaseView):
             HTTPNoContent: on success response
         """
         package_base = self.request.match_info["package"]
-        self.service().logs_remove(package_base, None)
+        version = self.request.query.get("version")
+        self.service().package_logs_remove(package_base, version)
 
         raise HTTPNoContent
 
@@ -103,7 +104,7 @@ class LogsView(StatusViewGuard, BaseView):
 
         try:
             _, status = self.service().package_get(package_base)
-            logs = self.service().logs_get(package_base)
+            logs = self.service().package_logs_get(package_base)
         except UnknownPackageError:
             raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 
@@ -149,6 +150,6 @@ class LogsView(StatusViewGuard, BaseView):
         except Exception as ex:
             raise HTTPBadRequest(reason=str(ex))
 
-        self.service().logs_update(LogRecordId(package_base, version), created, record)
+        self.service().package_logs_update(LogRecordId(package_base, version), created, record)
 
         raise HTTPNoContent

--- a/src/ahriman/web/views/v1/packages/package.py
+++ b/src/ahriman/web/views/v1/packages/package.py
@@ -153,9 +153,9 @@ class PackageView(StatusViewGuard, BaseView):
 
         try:
             if package is None:
-                self.service().package_update(package_base, status)
+                self.service().package_status_update(package_base, status)
             else:
-                self.service().package_add(package, status)
+                self.service().package_update(package, status)
         except UnknownPackageError:
             raise HTTPBadRequest(reason=f"Package {package_base} is unknown, but no package body set")
 

--- a/src/ahriman/web/views/v1/packages/patch.py
+++ b/src/ahriman/web/views/v1/packages/patch.py
@@ -63,7 +63,7 @@ class PatchView(StatusViewGuard, BaseView):
         """
         package_base = self.request.match_info["package"]
         variable = self.request.match_info["patch"]
-        self.service().patches_remove(package_base, variable)
+        self.service().package_patches_remove(package_base, variable)
 
         raise HTTPNoContent
 
@@ -95,7 +95,7 @@ class PatchView(StatusViewGuard, BaseView):
         package_base = self.request.match_info["package"]
         variable = self.request.match_info["patch"]
 
-        patches = self.service().patches_get(package_base, variable)
+        patches = self.service().package_patches_get(package_base, variable)
 
         selected = next((patch for patch in patches if patch.key == variable), None)
         if selected is None:

--- a/src/ahriman/web/views/v1/packages/patch.py
+++ b/src/ahriman/web/views/v1/packages/patch.py
@@ -63,6 +63,7 @@ class PatchView(StatusViewGuard, BaseView):
         """
         package_base = self.request.match_info["package"]
         variable = self.request.match_info["patch"]
+
         self.service().package_patches_remove(package_base, variable)
 
         raise HTTPNoContent

--- a/src/ahriman/web/views/v1/packages/patches.py
+++ b/src/ahriman/web/views/v1/packages/patches.py
@@ -63,7 +63,7 @@ class PatchesView(StatusViewGuard, BaseView):
             Response: 200 with package patches on success
         """
         package_base = self.request.match_info["package"]
-        patches = self.service().patches_get(package_base, None)
+        patches = self.service().package_patches_get(package_base, None)
 
         response = [patch.view() for patch in patches]
         return json_response(response)
@@ -101,6 +101,6 @@ class PatchesView(StatusViewGuard, BaseView):
         except Exception as ex:
             raise HTTPBadRequest(reason=str(ex))
 
-        self.service().patches_update(package_base, PkgbuildPatch(key, value))
+        self.service().package_patches_update(package_base, PkgbuildPatch(key, value))
 
         raise HTTPNoContent

--- a/src/ahriman/web/views/v1/packages/patches.py
+++ b/src/ahriman/web/views/v1/packages/patches.py
@@ -96,7 +96,7 @@ class PatchesView(StatusViewGuard, BaseView):
 
         try:
             data = await self.request.json()
-            key = data["key"]
+            key = data.get("key")
             value = data["value"]
         except Exception as ex:
             raise HTTPBadRequest(reason=str(ex))

--- a/src/ahriman/web/views/v2/packages/logs.py
+++ b/src/ahriman/web/views/v2/packages/logs.py
@@ -69,7 +69,7 @@ class LogsView(StatusViewGuard, BaseView):
         package_base = self.request.match_info["package"]
         limit, offset = self.page()
         try:
-            logs = self.service().package_logs_get(package_base, limit, offset)
+            logs = self.service(package_base=package_base).package_logs_get(package_base, limit, offset)
         except UnknownPackageError:
             raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 

--- a/src/ahriman/web/views/v2/packages/logs.py
+++ b/src/ahriman/web/views/v2/packages/logs.py
@@ -19,9 +19,8 @@
 #
 import aiohttp_apispec  # type: ignore[import-untyped]
 
-from aiohttp.web import HTTPNotFound, Response, json_response
+from aiohttp.web import Response, json_response
 
-from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.user_access import UserAccess
 from ahriman.web.schemas import AuthSchema, ErrorSchema, LogSchema, PackageNameSchema, PaginationSchema
 from ahriman.web.views.base import BaseView
@@ -68,10 +67,8 @@ class LogsView(StatusViewGuard, BaseView):
         """
         package_base = self.request.match_info["package"]
         limit, offset = self.page()
-        try:
-            logs = self.service(package_base=package_base).package_logs_get(package_base, limit, offset)
-        except UnknownPackageError:
-            raise HTTPNotFound(reason=f"Package {package_base} is unknown")
+
+        logs = self.service(package_base=package_base).package_logs_get(package_base, limit, offset)
 
         response = [
             {

--- a/src/ahriman/web/views/v2/packages/logs.py
+++ b/src/ahriman/web/views/v2/packages/logs.py
@@ -69,7 +69,7 @@ class LogsView(StatusViewGuard, BaseView):
         package_base = self.request.match_info["package"]
         limit, offset = self.page()
         try:
-            logs = self.service().logs_get(package_base, limit, offset)
+            logs = self.service().package_logs_get(package_base, limit, offset)
         except UnknownPackageError:
             raise HTTPNotFound(reason=f"Package {package_base} is unknown")
 

--- a/src/ahriman/web/web.py
+++ b/src/ahriman/web/web.py
@@ -30,6 +30,7 @@ from ahriman.core.database import SQLite
 from ahriman.core.distributed import WorkersCache
 from ahriman.core.exceptions import InitializeError
 from ahriman.core.spawn import Spawn
+from ahriman.core.status import Client
 from ahriman.core.status.watcher import Watcher
 from ahriman.models.repository_id import RepositoryId
 from ahriman.web.apispec import setup_apispec
@@ -167,7 +168,8 @@ def setup_server(configuration: Configuration, spawner: Spawn, repositories: lis
     watchers: dict[RepositoryId, Watcher] = {}
     for repository_id in repositories:
         application.logger.info("load repository %s", repository_id)
-        watchers[repository_id] = Watcher(repository_id, database)
+        client = Client.load(repository_id, configuration, database, report=False)  # explicitly load local client
+        watchers[repository_id] = Watcher(client)
     application[WatcherKey] = watchers
     # workers cache
     application[WorkersKey] = WorkersCache(configuration)

--- a/tests/ahriman/application/application/test_application.py
+++ b/tests/ahriman/application/application/test_application.py
@@ -93,8 +93,7 @@ def test_with_dependencies(application: Application, package_ahriman: Package, p
                                       side_effect=lambda *args: packages[args[0].name])
     packages_mock = mocker.patch("ahriman.application.application.Application._known_packages",
                                  return_value={"devtools", "python-build", "python-pytest"})
-    update_remote_mock = mocker.patch("ahriman.core.database.SQLite.package_base_update")
-    status_client_mock = mocker.patch("ahriman.core.status.client.Client.set_unknown")
+    status_client_mock = mocker.patch("ahriman.core.status.Client.set_unknown")
 
     result = application.with_dependencies([package_ahriman], process_dependencies=True)
     assert {package.base: package for package in result} == packages
@@ -107,11 +106,6 @@ def test_with_dependencies(application: Application, package_ahriman: Package, p
     ], any_order=True)
     packages_mock.assert_called_once_with()
 
-    update_remote_mock.assert_has_calls([
-        MockCall(package_python_schedule),
-        MockCall(packages["python"]),
-        MockCall(packages["python-installer"]),
-    ], any_order=True)
     status_client_mock.assert_has_calls([
         MockCall(package_python_schedule),
         MockCall(packages["python"]),

--- a/tests/ahriman/application/application/test_application_packages.py
+++ b/tests/ahriman/application/application/test_application_packages.py
@@ -41,11 +41,11 @@ def test_add_aur(application_packages: ApplicationPackages, package_ahriman: Pac
     """
     mocker.patch("ahriman.models.package.Package.from_aur", return_value=package_ahriman)
     build_queue_mock = mocker.patch("ahriman.core.database.SQLite.build_queue_insert")
-    update_remote_mock = mocker.patch("ahriman.core.database.SQLite.package_base_update")
+    status_client_mock = mocker.patch("ahriman.core.status.Client.set_unknown")
 
     application_packages._add_aur(package_ahriman.base, "packager")
     build_queue_mock.assert_called_once_with(package_ahriman)
-    update_remote_mock.assert_called_once_with(package_ahriman)
+    status_client_mock.assert_called_once_with(package_ahriman)
 
 
 def test_add_directory(application_packages: ApplicationPackages, package_ahriman: Package,
@@ -153,11 +153,11 @@ def test_add_repository(application_packages: ApplicationPackages, package_ahrim
     """
     mocker.patch("ahriman.models.package.Package.from_official", return_value=package_ahriman)
     build_queue_mock = mocker.patch("ahriman.core.database.SQLite.build_queue_insert")
-    update_remote_mock = mocker.patch("ahriman.core.database.SQLite.package_base_update")
+    status_client_mock = mocker.patch("ahriman.core.status.Client.set_unknown")
 
     application_packages._add_repository(package_ahriman.base, "packager")
     build_queue_mock.assert_called_once_with(package_ahriman)
-    update_remote_mock.assert_called_once_with(package_ahriman)
+    status_client_mock.assert_called_once_with(package_ahriman)
 
 
 def test_add_add_archive(application_packages: ApplicationPackages, package_ahriman: Package,

--- a/tests/ahriman/application/application/test_application_properties.py
+++ b/tests/ahriman/application/application/test_application_properties.py
@@ -1,15 +1,15 @@
 from ahriman.application.application.application_properties import ApplicationProperties
 
 
-def test_create_tree(application_properties: ApplicationProperties) -> None:
-    """
-    must have repository attribute
-    """
-    assert application_properties.repository
-
-
 def test_architecture(application_properties: ApplicationProperties) -> None:
     """
     must return repository architecture
     """
     assert application_properties.architecture == application_properties.repository_id.architecture
+
+
+def test_reporter(application_properties: ApplicationProperties) -> None:
+    """
+    must have reporter attribute
+    """
+    assert application_properties.reporter

--- a/tests/ahriman/application/application/test_application_repository.py
+++ b/tests/ahriman/application/application/test_application_repository.py
@@ -17,14 +17,12 @@ def test_changes(application_repository: ApplicationRepository, package_ahriman:
     must generate changes for the packages
     """
     changes = Changes("hash", "change")
-    hashes_mock = mocker.patch("ahriman.core.database.SQLite.hashes_get", return_value={
-        package_ahriman.base: changes.last_commit_sha,
-    })
+    hashes_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_get", return_value=changes)
     changes_mock = mocker.patch("ahriman.core.repository.Repository.package_changes", return_value=changes)
-    report_mock = mocker.patch("ahriman.core.status.client.Client.package_changes_set")
+    report_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_update")
 
     application_repository.changes([package_ahriman])
-    hashes_mock.assert_called_once_with()
+    hashes_mock.assert_called_once_with(package_ahriman.base)
     changes_mock.assert_called_once_with(package_ahriman, changes.last_commit_sha)
     report_mock.assert_called_once_with(package_ahriman.base, changes)
 
@@ -34,9 +32,8 @@ def test_changes_skip(application_repository: ApplicationRepository, package_ahr
     """
     must skip change generation if no last commit sha has been found
     """
-    mocker.patch("ahriman.core.database.SQLite.hashes_get", return_value={})
     changes_mock = mocker.patch("ahriman.core.repository.Repository.package_changes")
-    report_mock = mocker.patch("ahriman.core.status.client.Client.package_changes_set")
+    report_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_update")
 
     application_repository.changes([package_ahriman])
     changes_mock.assert_not_called()

--- a/tests/ahriman/application/handlers/test_handler_add.py
+++ b/tests/ahriman/application/handlers/test_handler_add.py
@@ -62,11 +62,11 @@ def test_run_with_patches(args: argparse.Namespace, configuration: Configuration
     args.variable = ["KEY=VALUE"]
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
     mocker.patch("ahriman.application.application.Application.add")
-    application_mock = mocker.patch("ahriman.core.database.SQLite.patches_insert")
+    application_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_update")
 
     _, repository_id = configuration.check_loaded()
     Add.run(args, repository_id, configuration, report=False)
-    application_mock.assert_called_once_with(args.package[0], [PkgbuildPatch("KEY", "VALUE")])
+    application_mock.assert_called_once_with(args.package[0], PkgbuildPatch("KEY", "VALUE"))
 
 
 def test_run_with_updates(args: argparse.Namespace, configuration: Configuration, repository: Repository,

--- a/tests/ahriman/application/handlers/test_handler_change.py
+++ b/tests/ahriman/application/handlers/test_handler_change.py
@@ -34,7 +34,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, repository:
     """
     args = _default_args(args)
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    application_mock = mocker.patch("ahriman.core.status.client.Client.package_changes_get",
+    application_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_get",
                                     return_value=Changes("sha", "change"))
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
@@ -54,7 +54,7 @@ def test_run_empty_exception(args: argparse.Namespace, configuration: Configurat
     args = _default_args(args)
     args.exit_code = True
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    mocker.patch("ahriman.core.status.client.Client.package_changes_get", return_value=Changes())
+    mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_get", return_value=Changes())
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
     _, repository_id = configuration.check_loaded()
@@ -70,7 +70,7 @@ def test_run_remove(args: argparse.Namespace, configuration: Configuration, repo
     args = _default_args(args)
     args.action = Action.Remove
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    update_mock = mocker.patch("ahriman.core.status.client.Client.package_changes_set")
+    update_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_update")
 
     _, repository_id = configuration.check_loaded()
     Change.run(args, repository_id, configuration, report=False)

--- a/tests/ahriman/application/handlers/test_handler_patch.py
+++ b/tests/ahriman/application/handlers/test_handler_patch.py
@@ -161,12 +161,12 @@ def test_patch_set_list(application: Application, mocker: MockerFixture) -> None
     must list available patches for the command
     """
     get_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_get",
-                            return_value=[PkgbuildPatch(None, "patch")])
+                            return_value=[PkgbuildPatch(None, "patch"), PkgbuildPatch("version", "value")])
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
     Patch.patch_set_list(application, "ahriman", ["version"], False)
-    get_mock.assert_called_once_with("ahriman", "version")
+    get_mock.assert_called_once_with("ahriman", None)
     print_mock.assert_called_once_with(verbose=True, log_fn=pytest.helpers.anyvar(int), separator=" = ")
     check_mock.assert_called_once_with(False, False)
 

--- a/tests/ahriman/application/handlers/test_handler_patch.py
+++ b/tests/ahriman/application/handlers/test_handler_patch.py
@@ -160,13 +160,28 @@ def test_patch_set_list(application: Application, mocker: MockerFixture) -> None
     """
     must list available patches for the command
     """
-    get_mock = mocker.patch("ahriman.core.database.SQLite.patches_list",
-                            return_value={"ahriman": PkgbuildPatch(None, "patch")})
+    get_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_get",
+                            return_value=[PkgbuildPatch(None, "patch")])
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
     Patch.patch_set_list(application, "ahriman", ["version"], False)
-    get_mock.assert_called_once_with("ahriman", ["version"])
+    get_mock.assert_called_once_with("ahriman", "version")
+    print_mock.assert_called_once_with(verbose=True, log_fn=pytest.helpers.anyvar(int), separator=" = ")
+    check_mock.assert_called_once_with(False, False)
+
+
+def test_patch_set_list_all(application: Application, mocker: MockerFixture) -> None:
+    """
+    must list all available patches for the command
+    """
+    get_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_get",
+                            return_value=[PkgbuildPatch(None, "patch")])
+    print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
+    check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
+
+    Patch.patch_set_list(application, "ahriman", None, False)
+    get_mock.assert_called_once_with("ahriman", None)
     print_mock.assert_called_once_with(verbose=True, log_fn=pytest.helpers.anyvar(int), separator=" = ")
     check_mock.assert_called_once_with(False, False)
 
@@ -175,7 +190,7 @@ def test_patch_set_list_empty_exception(application: Application, mocker: Mocker
     """
     must raise ExitCode exception on empty patch list
     """
-    mocker.patch("ahriman.core.database.SQLite.patches_list", return_value={})
+    mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_get", return_value={})
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
     Patch.patch_set_list(application, "ahriman", [], True)
@@ -186,18 +201,27 @@ def test_patch_set_create(application: Application, package_ahriman: Package, mo
     """
     must create patch set for the package
     """
-    create_mock = mocker.patch("ahriman.core.database.SQLite.patches_insert")
+    create_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_update")
     Patch.patch_set_create(application, package_ahriman.base, PkgbuildPatch("version", package_ahriman.version))
-    create_mock.assert_called_once_with(package_ahriman.base, [PkgbuildPatch("version", package_ahriman.version)])
+    create_mock.assert_called_once_with(package_ahriman.base, PkgbuildPatch("version", package_ahriman.version))
 
 
 def test_patch_set_remove(application: Application, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must remove patch set for the package
     """
-    remove_mock = mocker.patch("ahriman.core.database.SQLite.patches_remove")
+    remove_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_remove")
     Patch.patch_set_remove(application, package_ahriman.base, ["version"])
-    remove_mock.assert_called_once_with(package_ahriman.base, ["version"])
+    remove_mock.assert_called_once_with(package_ahriman.base, "version")
+
+
+def test_patch_set_remove_all(application: Application, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must remove all patches for the package
+    """
+    remove_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_remove")
+    Patch.patch_set_remove(application, package_ahriman.base, None)
+    remove_mock.assert_called_once_with(package_ahriman.base, None)
 
 
 def test_disallow_multi_architecture_run() -> None:

--- a/tests/ahriman/application/handlers/test_handler_rebuild.py
+++ b/tests/ahriman/application/handlers/test_handler_rebuild.py
@@ -185,7 +185,7 @@ def test_extract_packages_by_status(application: Application, mocker: MockerFixt
         ("package2", BuildStatus(BuildStatusEnum.Failed)),
     ])
     assert Rebuild.extract_packages(application, BuildStatusEnum.Failed, from_database=True) == ["package2"]
-    packages_mock.assert_called_once_with()
+    packages_mock.assert_called_once_with(application.repository_id)
 
 
 def test_extract_packages_from_database(application: Application, mocker: MockerFixture) -> None:
@@ -194,4 +194,4 @@ def test_extract_packages_from_database(application: Application, mocker: Mocker
     """
     packages_mock = mocker.patch("ahriman.core.database.SQLite.packages_get")
     Rebuild.extract_packages(application, None, from_database=True)
-    packages_mock.assert_called_once_with()
+    packages_mock.assert_called_once_with(application.repository_id)

--- a/tests/ahriman/application/handlers/test_handler_status.py
+++ b/tests/ahriman/application/handlers/test_handler_status.py
@@ -37,8 +37,8 @@ def test_run(args: argparse.Namespace, configuration: Configuration, repository:
     """
     args = _default_args(args)
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    application_mock = mocker.patch("ahriman.core.status.client.Client.status_get")
-    packages_mock = mocker.patch("ahriman.core.status.client.Client.package_get",
+    application_mock = mocker.patch("ahriman.core.status.Client.status_get")
+    packages_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_get",
                                  return_value=[(package_ahriman, BuildStatus(BuildStatusEnum.Success)),
                                                (package_python_schedule, BuildStatus(BuildStatusEnum.Failed))])
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
@@ -63,8 +63,8 @@ def test_run_empty_exception(args: argparse.Namespace, configuration: Configurat
     args = _default_args(args)
     args.exit_code = True
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    mocker.patch("ahriman.core.status.client.Client.status_get")
-    mocker.patch("ahriman.core.status.client.Client.package_get", return_value=[])
+    mocker.patch("ahriman.core.status.Client.status_get")
+    mocker.patch("ahriman.core.status.local_client.LocalClient.package_get", return_value=[])
     check_mock = mocker.patch("ahriman.application.handlers.Handler.check_if_empty")
 
     _, repository_id = configuration.check_loaded()
@@ -80,7 +80,7 @@ def test_run_verbose(args: argparse.Namespace, configuration: Configuration, rep
     args = _default_args(args)
     args.info = True
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    mocker.patch("ahriman.core.status.client.Client.package_get",
+    mocker.patch("ahriman.core.status.local_client.LocalClient.package_get",
                  return_value=[(package_ahriman, BuildStatus(BuildStatusEnum.Success))])
     print_mock = mocker.patch("ahriman.core.formatters.Printer.print")
 
@@ -100,7 +100,7 @@ def test_run_with_package_filter(args: argparse.Namespace, configuration: Config
     args = _default_args(args)
     args.package = [package_ahriman.base]
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    packages_mock = mocker.patch("ahriman.core.status.client.Client.package_get",
+    packages_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_get",
                                  return_value=[(package_ahriman, BuildStatus(BuildStatusEnum.Success))])
 
     _, repository_id = configuration.check_loaded()
@@ -115,7 +115,7 @@ def test_run_by_status(args: argparse.Namespace, configuration: Configuration, r
     """
     args = _default_args(args)
     args.status = BuildStatusEnum.Failed
-    mocker.patch("ahriman.core.status.client.Client.package_get",
+    mocker.patch("ahriman.core.status.local_client.LocalClient.package_get",
                  return_value=[(package_ahriman, BuildStatus(BuildStatusEnum.Success)),
                                (package_python_schedule, BuildStatus(BuildStatusEnum.Failed))])
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)

--- a/tests/ahriman/application/handlers/test_handler_status_update.py
+++ b/tests/ahriman/application/handlers/test_handler_status_update.py
@@ -34,7 +34,7 @@ def test_run(args: argparse.Namespace, configuration: Configuration, repository:
     """
     args = _default_args(args)
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    update_self_mock = mocker.patch("ahriman.core.status.client.Client.status_update")
+    update_self_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.status_update")
 
     _, repository_id = configuration.check_loaded()
     StatusUpdate.run(args, repository_id, configuration, report=False)
@@ -42,20 +42,17 @@ def test_run(args: argparse.Namespace, configuration: Configuration, repository:
 
 
 def test_run_packages(args: argparse.Namespace, configuration: Configuration, repository: Repository,
-                      package_ahriman: Package, mocker: MockerFixture) -> None:
+                      mocker: MockerFixture) -> None:
     """
     must run command with specified packages
     """
     args = _default_args(args)
-    args.package = [package_ahriman.base, "package"]
+    args.package = ["package"]
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    mocker.patch("ahriman.core.repository.repository.Repository.packages", return_value=[package_ahriman])
-    add_mock = mocker.patch("ahriman.core.status.client.Client.package_add")
-    update_mock = mocker.patch("ahriman.core.status.client.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_update")
 
     _, repository_id = configuration.check_loaded()
     StatusUpdate.run(args, repository_id, configuration, report=False)
-    add_mock.assert_called_once_with(package_ahriman, args.status)
     update_mock.assert_called_once_with("package", args.status)
 
 
@@ -68,7 +65,7 @@ def test_run_remove(args: argparse.Namespace, configuration: Configuration, repo
     args.package = [package_ahriman.base]
     args.action = Action.Remove
     mocker.patch("ahriman.core.repository.Repository.load", return_value=repository)
-    update_mock = mocker.patch("ahriman.core.status.client.Client.package_remove")
+    update_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_remove")
 
     _, repository_id = configuration.check_loaded()
     StatusUpdate.run(args, repository_id, configuration, report=False)

--- a/tests/ahriman/application/test_lock.py
+++ b/tests/ahriman/application/test_lock.py
@@ -64,7 +64,7 @@ def test_check_version(lock: Lock, mocker: MockerFixture) -> None:
     """
     must check version correctly
     """
-    mocker.patch("ahriman.core.status.client.Client.status_get",
+    mocker.patch("ahriman.core.status.Client.status_get",
                  return_value=InternalStatus(status=BuildStatus(), version=__version__))
     logging_mock = mocker.patch("logging.Logger.warning")
 
@@ -76,7 +76,7 @@ def test_check_version_mismatch(lock: Lock, mocker: MockerFixture) -> None:
     """
     must check mismatched version correctly
     """
-    mocker.patch("ahriman.core.status.client.Client.status_get",
+    mocker.patch("ahriman.core.status.Client.status_get",
                  return_value=InternalStatus(status=BuildStatus(), version="version"))
     logging_mock = mocker.patch("logging.Logger.warning")
 
@@ -184,7 +184,7 @@ def test_enter(lock: Lock, mocker: MockerFixture) -> None:
     watch_mock = mocker.patch("ahriman.application.lock.Lock.watch")
     clear_mock = mocker.patch("ahriman.application.lock.Lock.clear")
     create_mock = mocker.patch("ahriman.application.lock.Lock.create")
-    update_status_mock = mocker.patch("ahriman.core.status.client.Client.status_update")
+    update_status_mock = mocker.patch("ahriman.core.status.Client.status_update")
 
     with lock:
         pass
@@ -203,7 +203,7 @@ def test_exit_with_exception(lock: Lock, mocker: MockerFixture) -> None:
     mocker.patch("ahriman.application.lock.Lock.check_user")
     mocker.patch("ahriman.application.lock.Lock.clear")
     mocker.patch("ahriman.application.lock.Lock.create")
-    update_status_mock = mocker.patch("ahriman.core.status.client.Client.status_update")
+    update_status_mock = mocker.patch("ahriman.core.status.Client.status_update")
 
     with pytest.raises(Exception):
         with lock:

--- a/tests/ahriman/application/test_lock.py
+++ b/tests/ahriman/application/test_lock.py
@@ -27,7 +27,7 @@ def test_path(args: argparse.Namespace, configuration: Configuration) -> None:
 
     with pytest.raises(ValueError):
         args.lock = Path("/")
-        Lock(args, repository_id, configuration).path  # special case
+        assert Lock(args, repository_id, configuration).path  # special case
 
 
 def test_check_user(lock: Lock, mocker: MockerFixture) -> None:
@@ -205,7 +205,7 @@ def test_exit_with_exception(lock: Lock, mocker: MockerFixture) -> None:
     mocker.patch("ahriman.application.lock.Lock.create")
     update_status_mock = mocker.patch("ahriman.core.status.Client.status_update")
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         with lock:
-            raise Exception()
+            raise ValueError()
     update_status_mock.assert_has_calls([MockCall(BuildStatusEnum.Building), MockCall(BuildStatusEnum.Failed)])

--- a/tests/ahriman/core/alpm/test_pacman.py
+++ b/tests/ahriman/core/alpm/test_pacman.py
@@ -190,7 +190,7 @@ def test_files(pacman: Pacman, package_ahriman: Package, mocker: MockerFixture, 
     files = pacman.files()
     assert len(files) == 2
     assert package_ahriman.base in files
-    assert Path("usr/bin/ahriman") in files[package_ahriman.base]
+    assert "usr/bin/ahriman" in files[package_ahriman.base]
     open_mock.assert_called_once_with(pytest.helpers.anyvar(int), "r:gz")
 
 

--- a/tests/ahriman/core/alpm/test_pacman.py
+++ b/tests/ahriman/core/alpm/test_pacman.py
@@ -128,7 +128,7 @@ def test_database_copy_database_exist(pacman: Pacman, mocker: MockerFixture) -> 
     copy_mock.assert_not_called()
 
 
-def test_database_init(pacman: Pacman, configuration: Configuration) -> None:
+def test_database_init(pacman: Pacman) -> None:
     """
     must init database with settings
     """
@@ -184,14 +184,15 @@ def test_files(pacman: Pacman, package_ahriman: Package, mocker: MockerFixture, 
     pacman.handle = handle_mock
     tarball = resource_path_root / "core" / "arcanisrepo.files.tar.gz"
 
-    mocker.patch("pathlib.Path.is_file", return_value=True)
-    open_mock = mocker.patch("ahriman.core.alpm.pacman.tarfile.open", return_value=tarfile.open(tarball, "r:gz"))
+    with tarfile.open(tarball, "r:gz") as fd:
+        mocker.patch("pathlib.Path.is_file", return_value=True)
+        open_mock = mocker.patch("ahriman.core.alpm.pacman.tarfile.open", return_value=fd)
 
-    files = pacman.files()
-    assert len(files) == 2
-    assert package_ahriman.base in files
-    assert "usr/bin/ahriman" in files[package_ahriman.base]
-    open_mock.assert_called_once_with(pytest.helpers.anyvar(int), "r:gz")
+        files = pacman.files()
+        assert len(files) == 2
+        assert package_ahriman.base in files
+        assert "usr/bin/ahriman" in files[package_ahriman.base]
+        open_mock.assert_called_once_with(pytest.helpers.anyvar(int), "r:gz")
 
 
 def test_files_package(pacman: Pacman, package_ahriman: Package, mocker: MockerFixture,
@@ -205,12 +206,13 @@ def test_files_package(pacman: Pacman, package_ahriman: Package, mocker: MockerF
 
     tarball = resource_path_root / "core" / "arcanisrepo.files.tar.gz"
 
-    mocker.patch("pathlib.Path.is_file", return_value=True)
-    mocker.patch("ahriman.core.alpm.pacman.tarfile.open", return_value=tarfile.open(tarball, "r:gz"))
+    with tarfile.open(tarball, "r:gz") as fd:
+        mocker.patch("pathlib.Path.is_file", return_value=True)
+        mocker.patch("ahriman.core.alpm.pacman.tarfile.open", return_value=fd)
 
-    files = pacman.files(package_ahriman.base)
-    assert len(files) == 1
-    assert package_ahriman.base in files
+        files = pacman.files(package_ahriman.base)
+        assert len(files) == 1
+        assert package_ahriman.base in files
 
 
 def test_files_skip(pacman: Pacman, mocker: MockerFixture) -> None:

--- a/tests/ahriman/core/database/operations/test_changes_operations.py
+++ b/tests/ahriman/core/database/operations/test_changes_operations.py
@@ -53,13 +53,3 @@ def test_changes_insert_remove_full(database: SQLite, package_ahriman: Package,
     assert database.changes_get(package_python_schedule.base).changes is None
     assert database.changes_get(
         package_ahriman.base, RepositoryId("i686", database._repository_id.name)).changes == "change2"
-
-
-def test_hashes_get(database: SQLite, package_ahriman: Package, package_python_schedule: Package) -> None:
-    """
-    must return non-empty hashes for packages
-    """
-    database.changes_insert(package_ahriman.base, Changes("sha1", "change1"))
-    database.changes_insert(package_python_schedule.base, Changes())
-
-    assert database.hashes_get() == {package_ahriman.base: "sha1"}

--- a/tests/ahriman/core/database/operations/test_dependencies_operations.py
+++ b/tests/ahriman/core/database/operations/test_dependencies_operations.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from ahriman.core.database import SQLite
 from ahriman.models.dependencies import Dependencies
 from ahriman.models.package import Package
@@ -10,16 +8,19 @@ def test_dependencies_insert_get(database: SQLite, package_ahriman: Package) -> 
     """
     must insert and get dependencies
     """
-    dependencies = Dependencies(package_ahriman.base, {Path("usr/lib/python3.11/site-packages"): ["python"]})
-    database.dependencies_insert(dependencies)
-    assert database.dependencies_get(package_ahriman.base) == [dependencies]
+    dependencies = Dependencies({"usr/lib/python3.11/site-packages": ["python"]})
+    database.dependencies_insert(package_ahriman.base, dependencies)
+    assert database.dependencies_get(package_ahriman.base) == {package_ahriman.base: dependencies}
 
-    dependencies2 = Dependencies(package_ahriman.base, {Path("usr/lib/python3.11/site-packages"): ["python3"]})
-    database.dependencies_insert(dependencies2, RepositoryId("i686", database._repository_id.name))
-    assert database.dependencies_get() == [dependencies]
-    assert database.dependencies_get(package_ahriman.base) == [dependencies]
-    assert database.dependencies_get(
-        package_ahriman.base, RepositoryId("i686", database._repository_id.name)) == [dependencies2]
+    dependencies2 = Dependencies({"usr/lib/python3.11/site-packages": ["python3"]})
+    database.dependencies_insert(
+        package_ahriman.base, dependencies2, RepositoryId(
+            "i686", database._repository_id.name))
+    assert database.dependencies_get() == {package_ahriman.base: dependencies}
+    assert database.dependencies_get(package_ahriman.base) == {package_ahriman.base: dependencies}
+    assert database.dependencies_get(package_ahriman.base, RepositoryId("i686", database._repository_id.name)) == {
+        package_ahriman.base: dependencies2
+    }
 
 
 def test_dependencies_insert_remove(database: SQLite, package_ahriman: Package,
@@ -27,23 +28,28 @@ def test_dependencies_insert_remove(database: SQLite, package_ahriman: Package,
     """
     must remove dependencies for the package
     """
-    dependencies1 = Dependencies(package_ahriman.base, {Path("usr"): ["python"]})
-    database.dependencies_insert(dependencies1)
-    dependencies2 = Dependencies(package_python_schedule.base, {Path("usr"): ["filesystem"]})
-    database.dependencies_insert(dependencies2)
-    dependencies3 = Dependencies(package_ahriman.base, {Path("usr"): ["python3"]})
-    database.dependencies_insert(dependencies3, RepositoryId("i686", database._repository_id.name))
+    dependencies1 = Dependencies({"usr": ["python"]})
+    database.dependencies_insert(package_ahriman.base, dependencies1)
+    dependencies2 = Dependencies({"usr": ["filesystem"]})
+    database.dependencies_insert(package_python_schedule.base, dependencies2)
+    dependencies3 = Dependencies({"usr": ["python3"]})
+    database.dependencies_insert(
+        package_ahriman.base, dependencies3, RepositoryId(
+            "i686", database._repository_id.name))
 
-    assert database.dependencies_get() == [dependencies1, dependencies2]
+    assert database.dependencies_get() == {
+        package_ahriman.base: dependencies1,
+        package_python_schedule.base: dependencies2,
+    }
 
     database.dependencies_remove(package_ahriman.base)
-    assert database.dependencies_get(package_ahriman.base) == []
-    assert database.dependencies_get(package_python_schedule.base) == [dependencies2]
+    assert database.dependencies_get(package_ahriman.base) == {}
+    assert database.dependencies_get(package_python_schedule.base) == {package_python_schedule.base: dependencies2}
 
     # insert null
     database.dependencies_remove(package_ahriman.base, RepositoryId("i686", database._repository_id.name))
-    assert database.dependencies_get(package_ahriman.base, RepositoryId("i686", database._repository_id.name)) == []
-    assert database.dependencies_get(package_python_schedule.base) == [dependencies2]
+    assert database.dependencies_get(package_ahriman.base, RepositoryId("i686", database._repository_id.name)) == {}
+    assert database.dependencies_get(package_python_schedule.base) == {package_python_schedule.base: dependencies2}
 
 
 def test_dependencies_insert_remove_full(database: SQLite, package_ahriman: Package,
@@ -51,11 +57,11 @@ def test_dependencies_insert_remove_full(database: SQLite, package_ahriman: Pack
     """
     must remove all dependencies for the repository
     """
-    database.dependencies_insert(Dependencies(package_ahriman.base, {Path("usr"): ["python"]}))
-    database.dependencies_insert(Dependencies(package_python_schedule.base, {Path("usr"): ["filesystem"]}))
-    database.dependencies_insert(Dependencies(package_ahriman.base, {Path("usr"): ["python3"]}),
+    database.dependencies_insert(package_ahriman.base, Dependencies({"usr": ["python"]}))
+    database.dependencies_insert(package_python_schedule.base, Dependencies({"usr": ["filesystem"]}))
+    database.dependencies_insert(package_ahriman.base, Dependencies({"usr": ["python3"]}),
                                  RepositoryId("i686", database._repository_id.name))
 
     database.dependencies_remove(None)
-    assert database.dependencies_get() == []
+    assert database.dependencies_get() == {}
     assert database.dependencies_get(package_ahriman.base, RepositoryId("i686", database._repository_id.name))

--- a/tests/ahriman/core/database/operations/test_package_operations.py
+++ b/tests/ahriman/core/database/operations/test_package_operations.py
@@ -7,8 +7,6 @@ from unittest.mock import call as MockCall
 from ahriman.core.database import SQLite
 from ahriman.models.build_status import BuildStatus
 from ahriman.models.package import Package
-from ahriman.models.package_source import PackageSource
-from ahriman.models.remote_source import RemoteSource
 
 
 def test_package_remove_package_base(database: SQLite, connection: Connection) -> None:
@@ -183,26 +181,6 @@ def test_package_update_update(database: SQLite, package_ahriman: Package) -> No
     assert next(db_package.version
                 for db_package, _ in database.packages_get()
                 if db_package.base == package_ahriman.base) == package_ahriman.version
-
-
-def test_remote_update_get(database: SQLite, package_ahriman: Package) -> None:
-    """
-    must insert and retrieve package remote
-    """
-    database.package_base_update(package_ahriman)
-    assert database.remotes_get()[package_ahriman.base] == package_ahriman.remote
-
-
-def test_remote_update_update(database: SQLite, package_ahriman: Package) -> None:
-    """
-    must perform package remote update for existing package
-    """
-    database.package_base_update(package_ahriman)
-    remote_source = RemoteSource(source=PackageSource.Repository)
-    package_ahriman.remote = remote_source
-
-    database.package_base_update(package_ahriman)
-    assert database.remotes_get()[package_ahriman.base] == remote_source
 
 
 def test_status_update(database: SQLite, package_ahriman: Package) -> None:

--- a/tests/ahriman/core/database/operations/test_package_operations.py
+++ b/tests/ahriman/core/database/operations/test_package_operations.py
@@ -165,7 +165,6 @@ def test_package_update_remove_get(database: SQLite, package_ahriman: Package) -
     """
     must insert, remove and retrieve package
     """
-    status = BuildStatus()
     database.package_update(package_ahriman)
     database.package_remove(package_ahriman.base)
     assert not database.packages_get()

--- a/tests/ahriman/core/database/test_sqlite.py
+++ b/tests/ahriman/core/database/test_sqlite.py
@@ -44,6 +44,7 @@ def test_package_clear(database: SQLite, mocker: MockerFixture) -> None:
     logs_mock = mocker.patch("ahriman.core.database.SQLite.logs_remove")
     changes_mock = mocker.patch("ahriman.core.database.SQLite.changes_remove")
     dependencies_mock = mocker.patch("ahriman.core.database.SQLite.dependencies_remove")
+    tree_clear_mock = mocker.patch("ahriman.models.repository_paths.RepositoryPaths.tree_clear")
 
     database.package_clear("package")
     build_queue_mock.assert_called_once_with("package")
@@ -51,3 +52,4 @@ def test_package_clear(database: SQLite, mocker: MockerFixture) -> None:
     logs_mock.assert_called_once_with("package", None)
     changes_mock.assert_called_once_with("package")
     dependencies_mock.assert_called_once_with("package")
+    tree_clear_mock.assert_called_once_with("package")

--- a/tests/ahriman/core/gitremote/test_remote_push_trigger.py
+++ b/tests/ahriman/core/gitremote/test_remote_push_trigger.py
@@ -1,8 +1,8 @@
 from pytest_mock import MockerFixture
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.database import SQLite
 from ahriman.core.gitremote import RemotePushTrigger
+from ahriman.core.status import Client
 from ahriman.models.package import Package
 from ahriman.models.result import Result
 
@@ -19,15 +19,15 @@ def test_configuration_sections(configuration: Configuration) -> None:
 
 
 def test_on_result(configuration: Configuration, result: Result, package_ahriman: Package,
-                   database: SQLite, mocker: MockerFixture) -> None:
+                   local_client: Client, mocker: MockerFixture) -> None:
     """
     must push changes on result
     """
-    database_mock = mocker.patch("ahriman.core._Context.get", return_value=database)
+    database_mock = mocker.patch("ahriman.core._Context.get", return_value=local_client)
     run_mock = mocker.patch("ahriman.core.gitremote.remote_push.RemotePush.run")
     _, repository_id = configuration.check_loaded()
     trigger = RemotePushTrigger(repository_id, configuration)
 
     trigger.on_result(result, [package_ahriman])
-    database_mock.assert_called_once_with(SQLite)
+    database_mock.assert_called_once_with(Client)
     run_mock.assert_called_once_with(result)

--- a/tests/ahriman/core/log/test_lazy_logging.py
+++ b/tests/ahriman/core/log/test_lazy_logging.py
@@ -68,9 +68,9 @@ def test_in_package_context_failed(database: SQLite, package_ahriman: Package, m
     mocker.patch("ahriman.core.log.LazyLogging._package_logger_set")
     reset_mock = mocker.patch("ahriman.core.log.LazyLogging._package_logger_reset")
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         with database.in_package_context(package_ahriman.base, ""):
-            raise Exception()
+            raise ValueError()
 
     reset_mock.assert_called_once_with()
 
@@ -81,11 +81,3 @@ def test_logger(database: SQLite) -> None:
     """
     assert database.logger
     assert database.logger.name == "ahriman.core.database.sqlite.SQLite"
-
-
-def test_logger_attribute_error(database: SQLite) -> None:
-    """
-    must raise AttributeError in case if no attribute found
-    """
-    with pytest.raises(AttributeError):
-        database.loggerrrr

--- a/tests/ahriman/core/repository/test_package_info.py
+++ b/tests/ahriman/core/repository/test_package_info.py
@@ -21,9 +21,9 @@ def test_load_archives(package_ahriman: Package, package_python_schedule: Packag
         for package, props in package_python_schedule.packages.items()
     ] + [package_ahriman]
     mocker.patch("ahriman.models.package.Package.from_archive", side_effect=single_packages)
-    mocker.patch("ahriman.core.database.SQLite.remotes_get", return_value={
-        package_ahriman.base: package_ahriman.base
-    })
+    mocker.patch("ahriman.core.status.local_client.LocalClient.package_get", return_value=[
+        (package_ahriman, None),
+    ])
 
     packages = package_info.load_archives([Path("a.pkg.tar.xz"), Path("b.pkg.tar.xz"), Path("c.pkg.tar.xz")])
     assert len(packages) == 2

--- a/tests/ahriman/core/repository/test_repository.py
+++ b/tests/ahriman/core/repository/test_repository.py
@@ -6,6 +6,7 @@ from ahriman.core.configuration import Configuration
 from ahriman.core.database import SQLite
 from ahriman.core.repository import Repository
 from ahriman.core.sign.gpg import GPG
+from ahriman.core.status import Client
 
 
 def test_load(configuration: Configuration, database: SQLite, mocker: MockerFixture) -> None:
@@ -32,5 +33,6 @@ def test_set_context(configuration: Configuration, database: SQLite, mocker: Moc
         MockCall(Configuration, instance.configuration),
         MockCall(Pacman, instance.pacman),
         MockCall(GPG, instance.sign),
+        MockCall(Client, instance.reporter),
         MockCall(Repository, instance),
     ])

--- a/tests/ahriman/core/status/conftest.py
+++ b/tests/ahriman/core/status/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.status.client import Client
+from ahriman.core.status import Client
 from ahriman.core.status.web_client import WebClient
 
 

--- a/tests/ahriman/core/status/test_client.py
+++ b/tests/ahriman/core/status/test_client.py
@@ -94,14 +94,6 @@ def test_load_web_client_from_legacy_unix_socket(configuration: Configuration, d
     assert isinstance(Client.load(repository_id, configuration, database, report=True), WebClient)
 
 
-def test_package_add(client: Client, package_ahriman: Package) -> None:
-    """
-    must raise not implemented on package addition
-    """
-    with pytest.raises(NotImplementedError):
-        client.package_add(package_ahriman, BuildStatusEnum.Unknown)
-
-
 def test_package_changes_get(client: Client, package_ahriman: Package) -> None:
     """
     must raise not implemented on package changes request
@@ -198,19 +190,27 @@ def test_package_remove(client: Client, package_ahriman: Package) -> None:
         client.package_remove(package_ahriman.base)
 
 
-def test_package_update(client: Client, package_ahriman: Package) -> None:
+def test_package_status_update(client: Client, package_ahriman: Package) -> None:
     """
     must raise not implemented on package update
     """
     with pytest.raises(NotImplementedError):
-        client.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
+        client.package_status_update(package_ahriman.base, BuildStatusEnum.Unknown)
+
+
+def test_package_update(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on package addition
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_update(package_ahriman, BuildStatusEnum.Unknown)
 
 
 def test_set_building(client: Client, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must set building status to the package
     """
-    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.Client.package_status_update")
     client.set_building(package_ahriman.base)
 
     update_mock.assert_called_once_with(package_ahriman.base, BuildStatusEnum.Building)
@@ -220,7 +220,7 @@ def test_set_failed(client: Client, package_ahriman: Package, mocker: MockerFixt
     """
     must set failed status to the package
     """
-    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.Client.package_status_update")
     client.set_failed(package_ahriman.base)
 
     update_mock.assert_called_once_with(package_ahriman.base, BuildStatusEnum.Failed)
@@ -230,7 +230,7 @@ def test_set_pending(client: Client, package_ahriman: Package, mocker: MockerFix
     """
     must set building status to the package
     """
-    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.Client.package_status_update")
     client.set_pending(package_ahriman.base)
 
     update_mock.assert_called_once_with(package_ahriman.base, BuildStatusEnum.Pending)
@@ -240,7 +240,7 @@ def test_set_success(client: Client, package_ahriman: Package, mocker: MockerFix
     """
     must set success status to the package
     """
-    add_mock = mocker.patch("ahriman.core.status.Client.package_add")
+    add_mock = mocker.patch("ahriman.core.status.Client.package_update")
     client.set_success(package_ahriman)
 
     add_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Success)
@@ -250,7 +250,7 @@ def test_set_unknown(client: Client, package_ahriman: Package, mocker: MockerFix
     """
     must add new package with unknown status
     """
-    add_mock = mocker.patch("ahriman.core.status.Client.package_add")
+    add_mock = mocker.patch("ahriman.core.status.Client.package_update")
     client.set_unknown(package_ahriman)
 
     add_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Unknown)

--- a/tests/ahriman/core/status/test_client.py
+++ b/tests/ahriman/core/status/test_client.py
@@ -240,20 +240,32 @@ def test_set_success(client: Client, package_ahriman: Package, mocker: MockerFix
     """
     must set success status to the package
     """
-    add_mock = mocker.patch("ahriman.core.status.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
     client.set_success(package_ahriman)
 
-    add_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Success)
+    update_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Success)
 
 
 def test_set_unknown(client: Client, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must add new package with unknown status
     """
-    add_mock = mocker.patch("ahriman.core.status.Client.package_update")
+    mocker.patch("ahriman.core.status.Client.package_get", return_value=[])
+    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
     client.set_unknown(package_ahriman)
 
-    add_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Unknown)
+    update_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Unknown)
+
+
+def test_set_unknown_skip(client: Client, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must skip unknown status update in case if pacakge is already known
+    """
+    mocker.patch("ahriman.core.status.Client.package_get", return_value=[(package_ahriman, None)])
+    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
+    client.set_unknown(package_ahriman)
+
+    update_mock.assert_not_called()
 
 
 def test_status_get(client: Client) -> None:

--- a/tests/ahriman/core/status/test_client.py
+++ b/tests/ahriman/core/status/test_client.py
@@ -1,26 +1,39 @@
 import logging
+import pytest
 
 from pytest_mock import MockerFixture
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.status.client import Client
+from ahriman.core.database import SQLite
+from ahriman.core.status import Client
+from ahriman.core.status.local_client import LocalClient
 from ahriman.core.status.web_client import WebClient
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.changes import Changes
+from ahriman.models.dependencies import Dependencies
 from ahriman.models.internal_status import InternalStatus
 from ahriman.models.log_record_id import LogRecordId
 from ahriman.models.package import Package
+from ahriman.models.pkgbuild_patch import PkgbuildPatch
 
 
 def test_load_dummy_client(configuration: Configuration) -> None:
     """
+    must load dummy client if no settings and database set
+    """
+    _, repository_id = configuration.check_loaded()
+    assert isinstance(Client.load(repository_id, configuration, report=True), Client)
+
+
+def test_load_local_client(configuration: Configuration, database: SQLite) -> None:
+    """
     must load dummy client if no settings set
     """
     _, repository_id = configuration.check_loaded()
-    assert not isinstance(Client.load(repository_id, configuration, report=True), WebClient)
+    assert isinstance(Client.load(repository_id, configuration, database, report=True), LocalClient)
 
 
-def test_load_dummy_client_disabled(configuration: Configuration) -> None:
+def test_load_local_client_disabled(configuration: Configuration, database: SQLite) -> None:
     """
     must load dummy client if report is set to False
     """
@@ -28,10 +41,10 @@ def test_load_dummy_client_disabled(configuration: Configuration) -> None:
     configuration.set_option("web", "port", "8080")
 
     _, repository_id = configuration.check_loaded()
-    assert not isinstance(Client.load(repository_id, configuration, report=False), WebClient)
+    assert isinstance(Client.load(repository_id, configuration, database, report=False), LocalClient)
 
 
-def test_load_dummy_client_disabled_in_configuration(configuration: Configuration) -> None:
+def test_load_local_client_disabled_in_configuration(configuration: Configuration, database: SQLite) -> None:
     """
     must load dummy client if disabled in configuration
     """
@@ -40,19 +53,19 @@ def test_load_dummy_client_disabled_in_configuration(configuration: Configuratio
     configuration.set_option("status", "enabled", "no")
 
     _, repository_id = configuration.check_loaded()
-    assert not isinstance(Client.load(repository_id, configuration, report=True), WebClient)
+    assert isinstance(Client.load(repository_id, configuration, database, report=True), LocalClient)
 
 
-def test_load_full_client_from_address(configuration: Configuration) -> None:
+def test_load_web_client_from_address(configuration: Configuration, database: SQLite) -> None:
     """
     must load full client by using address
     """
     configuration.set_option("status", "address", "http://localhost:8080")
     _, repository_id = configuration.check_loaded()
-    assert isinstance(Client.load(repository_id, configuration, report=True), WebClient)
+    assert isinstance(Client.load(repository_id, configuration, database, report=True), WebClient)
 
 
-def test_load_full_client_from_legacy_host(configuration: Configuration) -> None:
+def test_load_web_client_from_legacy_host(configuration: Configuration, database: SQLite) -> None:
     """
     must load full client if host and port settings set
     """
@@ -60,82 +73,144 @@ def test_load_full_client_from_legacy_host(configuration: Configuration) -> None
     configuration.set_option("web", "port", "8080")
 
     _, repository_id = configuration.check_loaded()
-    assert isinstance(Client.load(repository_id, configuration, report=True), WebClient)
+    assert isinstance(Client.load(repository_id, configuration, database, report=True), WebClient)
 
 
-def test_load_full_client_from_legacy_address(configuration: Configuration) -> None:
+def test_load_web_client_from_legacy_address(configuration: Configuration, database: SQLite) -> None:
     """
     must load full client by using legacy address
     """
     configuration.set_option("web", "address", "http://localhost:8080")
     _, repository_id = configuration.check_loaded()
-    assert isinstance(Client.load(repository_id, configuration, report=True), WebClient)
+    assert isinstance(Client.load(repository_id, configuration, database, report=True), WebClient)
 
 
-def test_load_full_client_from_legacy_unix_socket(configuration: Configuration) -> None:
+def test_load_web_client_from_legacy_unix_socket(configuration: Configuration, database: SQLite) -> None:
     """
     must load full client by using unix socket
     """
     configuration.set_option("web", "unix_socket", "/var/lib/ahriman/ahriman-web.sock")
     _, repository_id = configuration.check_loaded()
-    assert isinstance(Client.load(repository_id, configuration, report=True), WebClient)
+    assert isinstance(Client.load(repository_id, configuration, database, report=True), WebClient)
 
 
 def test_package_add(client: Client, package_ahriman: Package) -> None:
     """
-    must process package addition without errors
+    must raise not implemented on package addition
     """
-    client.package_add(package_ahriman, BuildStatusEnum.Unknown)
+    with pytest.raises(NotImplementedError):
+        client.package_add(package_ahriman, BuildStatusEnum.Unknown)
 
 
 def test_package_changes_get(client: Client, package_ahriman: Package) -> None:
     """
-    must return null changes
+    must raise not implemented on package changes request
     """
-    assert client.package_changes_get(package_ahriman.base) == Changes()
+    with pytest.raises(NotImplementedError):
+        client.package_changes_get(package_ahriman.base)
 
 
-def test_package_changes_set(client: Client, package_ahriman: Package) -> None:
+def test_package_changes_update(client: Client, package_ahriman: Package) -> None:
     """
-    must process changes update without errors
+    must raise not implemented on changes update
     """
-    client.package_changes_set(package_ahriman.base, Changes())
+    with pytest.raises(NotImplementedError):
+        client.package_changes_update(package_ahriman.base, Changes())
+
+
+def test_package_dependencies_get(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on package dependencies request
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_dependencies_get(package_ahriman.base)
+
+
+def test_package_dependencies_update(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on dependencies update
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_dependencies_update(package_ahriman.base, Dependencies())
 
 
 def test_package_get(client: Client, package_ahriman: Package) -> None:
     """
-    must return empty package list
+    must raise not implemented on packages get
     """
-    assert client.package_get(package_ahriman.base) == []
-    assert client.package_get(None) == []
+    with pytest.raises(NotImplementedError):
+        assert client.package_get(package_ahriman.base)
 
 
-def test_package_logs(client: Client, package_ahriman: Package, log_record: logging.LogRecord) -> None:
+def test_package_logs_add(client: Client, package_ahriman: Package, log_record: logging.LogRecord) -> None:
     """
-    must process log record without errors
+    must process log record addition without exception
     """
-    client.package_logs(LogRecordId(package_ahriman.base, package_ahriman.version), log_record)
+    log_record_id = LogRecordId(package_ahriman.base, package_ahriman.version)
+    client.package_logs_add(log_record_id, log_record.created, log_record.getMessage())
+
+
+def test_package_logs_get(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on logs retrieval
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_logs_get(package_ahriman.base)
+
+
+def test_package_logs_remove(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on logs removal
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_logs_remove(package_ahriman.base, package_ahriman.version)
+
+
+def test_package_patches_get(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on patches retrieval
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_patches_get(package_ahriman.base, None)
+
+
+def test_package_patches_remove(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on patches removal
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_patches_remove(package_ahriman.base, None)
+
+
+def test_package_patches_update(client: Client, package_ahriman: Package) -> None:
+    """
+    must raise not implemented on patches addition
+    """
+    with pytest.raises(NotImplementedError):
+        client.package_patches_update(package_ahriman.base, PkgbuildPatch(None, ""))
 
 
 def test_package_remove(client: Client, package_ahriman: Package) -> None:
     """
-    must process remove without errors
+    must raise not implemented on package removal
     """
-    client.package_remove(package_ahriman.base)
+    with pytest.raises(NotImplementedError):
+        client.package_remove(package_ahriman.base)
 
 
 def test_package_update(client: Client, package_ahriman: Package) -> None:
     """
-    must update package status without errors
+    must raise not implemented on package update
     """
-    client.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
+    with pytest.raises(NotImplementedError):
+        client.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
 
 
 def test_set_building(client: Client, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must set building status to the package
     """
-    update_mock = mocker.patch("ahriman.core.status.client.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
     client.set_building(package_ahriman.base)
 
     update_mock.assert_called_once_with(package_ahriman.base, BuildStatusEnum.Building)
@@ -145,7 +220,7 @@ def test_set_failed(client: Client, package_ahriman: Package, mocker: MockerFixt
     """
     must set failed status to the package
     """
-    update_mock = mocker.patch("ahriman.core.status.client.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
     client.set_failed(package_ahriman.base)
 
     update_mock.assert_called_once_with(package_ahriman.base, BuildStatusEnum.Failed)
@@ -155,7 +230,7 @@ def test_set_pending(client: Client, package_ahriman: Package, mocker: MockerFix
     """
     must set building status to the package
     """
-    update_mock = mocker.patch("ahriman.core.status.client.Client.package_update")
+    update_mock = mocker.patch("ahriman.core.status.Client.package_update")
     client.set_pending(package_ahriman.base)
 
     update_mock.assert_called_once_with(package_ahriman.base, BuildStatusEnum.Pending)
@@ -165,7 +240,7 @@ def test_set_success(client: Client, package_ahriman: Package, mocker: MockerFix
     """
     must set success status to the package
     """
-    add_mock = mocker.patch("ahriman.core.status.client.Client.package_add")
+    add_mock = mocker.patch("ahriman.core.status.Client.package_add")
     client.set_success(package_ahriman)
 
     add_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Success)
@@ -175,7 +250,7 @@ def test_set_unknown(client: Client, package_ahriman: Package, mocker: MockerFix
     """
     must add new package with unknown status
     """
-    add_mock = mocker.patch("ahriman.core.status.client.Client.package_add")
+    add_mock = mocker.patch("ahriman.core.status.Client.package_add")
     client.set_unknown(package_ahriman)
 
     add_mock.assert_called_once_with(package_ahriman, BuildStatusEnum.Unknown)

--- a/tests/ahriman/core/status/test_local_client.py
+++ b/tests/ahriman/core/status/test_local_client.py
@@ -1,0 +1,182 @@
+import logging
+import pytest
+
+from pytest_mock import MockerFixture
+
+from ahriman.core.status.local_client import LocalClient
+from ahriman.models.build_status import BuildStatusEnum, BuildStatus
+from ahriman.models.changes import Changes
+from ahriman.models.dependencies import Dependencies
+from ahriman.models.log_record_id import LogRecordId
+from ahriman.models.package import Package
+from ahriman.models.pkgbuild_patch import PkgbuildPatch
+
+
+def test_package_add(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must process package addition
+    """
+    package_mock = mocker.patch("ahriman.core.database.SQLite.package_update")
+    status_mock = mocker.patch("ahriman.core.database.SQLite.status_update")
+
+    local_client.package_add(package_ahriman, BuildStatusEnum.Success)
+    package_mock.assert_called_once_with(package_ahriman, local_client.repository_id)
+    status_mock.assert_called_once_with(package_ahriman.base, pytest.helpers.anyvar(int), local_client.repository_id)
+
+
+def test_package_changes_get(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must retrieve package changes
+    """
+    changes_mock = mocker.patch("ahriman.core.database.SQLite.changes_get")
+    local_client.package_changes_get(package_ahriman.base)
+    changes_mock.assert_called_once_with(package_ahriman.base, local_client.repository_id)
+
+
+def test_package_changes_update(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must update package changes
+    """
+    changes_mock = mocker.patch("ahriman.core.database.SQLite.changes_insert")
+    changes = Changes()
+
+    local_client.package_changes_update(package_ahriman.base, changes)
+    changes_mock.assert_called_once_with(package_ahriman.base, changes, local_client.repository_id)
+
+
+def test_package_dependencies_get(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must retrieve package dependencies
+    """
+    dependencies_mock = mocker.patch("ahriman.core.database.SQLite.dependencies_get")
+    local_client.package_dependencies_get(package_ahriman.base)
+    dependencies_mock.assert_called_once_with(package_ahriman.base, local_client.repository_id)
+
+
+def test_package_dependencies_update(
+        local_client: LocalClient,
+        package_ahriman: Package,
+        mocker: MockerFixture) -> None:
+    """
+    must update package dependencies
+    """
+    dependencies_mock = mocker.patch("ahriman.core.database.SQLite.dependencies_insert")
+    local_client.package_dependencies_update(package_ahriman.base, Dependencies())
+    dependencies_mock.assert_called_once_with(package_ahriman.base, Dependencies(), local_client.repository_id)
+
+
+def test_package_get(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must retrieve packages
+    """
+    result = [(package_ahriman, BuildStatus())]
+    package_mock = mocker.patch("ahriman.core.database.SQLite.packages_get", return_value=result)
+    assert local_client.package_get(None) == result
+    package_mock.assert_called_once_with(local_client.repository_id)
+
+
+def test_package_get_package(local_client: LocalClient, package_ahriman: Package, package_python_schedule: Package,
+                             mocker: MockerFixture) -> None:
+    """
+    must retrieve specific package
+    """
+    result = [(package_ahriman, BuildStatus()), (package_python_schedule, BuildStatus())]
+    package_mock = mocker.patch("ahriman.core.database.SQLite.packages_get", return_value=result)
+    assert local_client.package_get(package_ahriman.base) == [result[0]]
+    package_mock.assert_called_once_with(local_client.repository_id)
+
+
+def test_package_logs_add(local_client: LocalClient, package_ahriman: Package, log_record: logging.LogRecord,
+                          mocker: MockerFixture) -> None:
+    """
+    must add package logs
+    """
+    logs_mock = mocker.patch("ahriman.core.database.SQLite.logs_insert")
+    log_record_id = LogRecordId(package_ahriman.base, package_ahriman.version)
+
+    local_client.package_logs_add(log_record_id, log_record.created, log_record.getMessage())
+    logs_mock.assert_called_once_with(log_record_id, log_record.created, log_record.getMessage(),
+                                      local_client.repository_id)
+
+
+def test_package_logs_get(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must retrieve package logs
+    """
+    logs_mock = mocker.patch("ahriman.core.database.SQLite.logs_get")
+    local_client.package_logs_get(package_ahriman.base, 1, 2)
+    logs_mock.assert_called_once_with(package_ahriman.base, 1, 2, local_client.repository_id)
+
+
+def test_package_logs_remove(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must remove package logs
+    """
+    logs_mock = mocker.patch("ahriman.core.database.SQLite.logs_remove")
+    local_client.package_logs_remove(package_ahriman.base, package_ahriman.version)
+    logs_mock.assert_called_once_with(package_ahriman.base, package_ahriman.version, local_client.repository_id)
+
+
+def test_package_patches_get(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must retrieve package patches
+    """
+    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_list")
+    local_client.package_patches_get(package_ahriman.base, None)
+    patches_mock.assert_called_once_with(package_ahriman.base, None)
+
+
+def test_package_patches_get_key(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must retrieve package patches for specific patch name
+    """
+    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_list")
+    local_client.package_patches_get(package_ahriman.base, "key")
+    patches_mock.assert_called_once_with(package_ahriman.base, ["key"])
+
+
+def test_package_patches_remove(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must remove package patches
+    """
+    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_remove")
+    local_client.package_patches_remove(package_ahriman.base, None)
+    patches_mock.assert_called_once_with(package_ahriman.base, None)
+
+
+def test_package_patches_remove_key(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must remove package specific package patch
+    """
+    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_remove")
+    local_client.package_patches_remove(package_ahriman.base, "key")
+    patches_mock.assert_called_once_with(package_ahriman.base, ["key"])
+
+
+def test_package_patches_update(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must add package patches
+    """
+    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_insert")
+    patch = PkgbuildPatch("key", "value")
+
+    local_client.package_patches_update(package_ahriman.base, patch)
+    patches_mock.assert_called_once_with(package_ahriman.base, [patch])
+
+
+def test_package_remove(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must remove package
+    """
+    package_mock = mocker.patch("ahriman.core.database.SQLite.package_clear")
+    local_client.package_remove(package_ahriman.base)
+    package_mock.assert_called_once_with(package_ahriman.base)
+
+
+def test_package_update(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must update package status
+    """
+    status_mock = mocker.patch("ahriman.core.database.SQLite.status_update")
+    local_client.package_update(package_ahriman.base, BuildStatusEnum.Success)
+    status_mock.assert_called_once_with(package_ahriman.base, pytest.helpers.anyvar(int), local_client.repository_id)

--- a/tests/ahriman/core/status/test_local_client.py
+++ b/tests/ahriman/core/status/test_local_client.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ahriman.core.status.local_client import LocalClient
-from ahriman.models.build_status import BuildStatusEnum, BuildStatus
+from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.changes import Changes
 from ahriman.models.dependencies import Dependencies
 from ahriman.models.log_record_id import LogRecordId

--- a/tests/ahriman/core/status/test_local_client.py
+++ b/tests/ahriman/core/status/test_local_client.py
@@ -12,18 +12,6 @@ from ahriman.models.package import Package
 from ahriman.models.pkgbuild_patch import PkgbuildPatch
 
 
-def test_package_add(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must process package addition
-    """
-    package_mock = mocker.patch("ahriman.core.database.SQLite.package_update")
-    status_mock = mocker.patch("ahriman.core.database.SQLite.status_update")
-
-    local_client.package_add(package_ahriman, BuildStatusEnum.Success)
-    package_mock.assert_called_once_with(package_ahriman, local_client.repository_id)
-    status_mock.assert_called_once_with(package_ahriman.base, pytest.helpers.anyvar(int), local_client.repository_id)
-
-
 def test_package_changes_get(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must retrieve package changes
@@ -173,10 +161,22 @@ def test_package_remove(local_client: LocalClient, package_ahriman: Package, moc
     package_mock.assert_called_once_with(package_ahriman.base)
 
 
-def test_package_update(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+def test_package_status_update(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must update package status
     """
     status_mock = mocker.patch("ahriman.core.database.SQLite.status_update")
-    local_client.package_update(package_ahriman.base, BuildStatusEnum.Success)
+    local_client.package_status_update(package_ahriman.base, BuildStatusEnum.Success)
+    status_mock.assert_called_once_with(package_ahriman.base, pytest.helpers.anyvar(int), local_client.repository_id)
+
+
+def test_package_update(local_client: LocalClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must process package addition
+    """
+    package_mock = mocker.patch("ahriman.core.database.SQLite.package_update")
+    status_mock = mocker.patch("ahriman.core.database.SQLite.status_update")
+
+    local_client.package_update(package_ahriman, BuildStatusEnum.Success)
+    package_mock.assert_called_once_with(package_ahriman, local_client.repository_id)
     status_mock.assert_called_once_with(package_ahriman.base, pytest.helpers.anyvar(int), local_client.repository_id)

--- a/tests/ahriman/core/status/test_watcher.py
+++ b/tests/ahriman/core/status/test_watcher.py
@@ -46,17 +46,6 @@ def test_load_known(watcher: Watcher, package_ahriman: Package, mocker: MockerFi
     assert status.status == BuildStatusEnum.Success
 
 
-def test_package_add(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must add package to cache
-    """
-    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_add")
-
-    watcher.package_add(package_ahriman, BuildStatusEnum.Unknown)
-    assert watcher.packages
-    cache_mock.assert_called_once_with(package_ahriman, pytest.helpers.anyvar(int))
-
-
 def test_package_get(watcher: Watcher, package_ahriman: Package) -> None:
     """
     must return package status
@@ -130,26 +119,37 @@ def test_package_remove_unknown(watcher: Watcher, package_ahriman: Package, mock
     cache_mock.assert_called_once_with(package_ahriman.base)
 
 
-def test_package_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+def test_package_status_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must update package status only for known package
     """
-    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_update")
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_status_update")
     watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
 
-    watcher.package_update(package_ahriman.base, BuildStatusEnum.Success)
+    watcher.package_status_update(package_ahriman.base, BuildStatusEnum.Success)
     cache_mock.assert_called_once_with(package_ahriman.base, pytest.helpers.anyvar(int))
     package, status = watcher._known[package_ahriman.base]
     assert package == package_ahriman
     assert status.status == BuildStatusEnum.Success
 
 
-def test_package_update_unknown(watcher: Watcher, package_ahriman: Package) -> None:
+def test_package_status_update_unknown(watcher: Watcher, package_ahriman: Package) -> None:
     """
     must fail on unknown package status update only
     """
     with pytest.raises(UnknownPackageError):
-        watcher.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
+        watcher.package_status_update(package_ahriman.base, BuildStatusEnum.Unknown)
+
+
+def test_package_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must add package to cache
+    """
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_update")
+
+    watcher.package_update(package_ahriman, BuildStatusEnum.Unknown)
+    assert watcher.packages
+    cache_mock.assert_called_once_with(package_ahriman, pytest.helpers.anyvar(int))
 
 
 def test_status_update(watcher: Watcher) -> None:

--- a/tests/ahriman/core/status/test_watcher.py
+++ b/tests/ahriman/core/status/test_watcher.py
@@ -1,16 +1,12 @@
 import pytest
 
 from pytest_mock import MockerFixture
-from unittest.mock import call as MockCall
 
 from ahriman.core.exceptions import UnknownPackageError
 from ahriman.core.status.watcher import Watcher
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
-from ahriman.models.changes import Changes
-from ahriman.models.dependencies import Dependencies
 from ahriman.models.log_record_id import LogRecordId
 from ahriman.models.package import Package
-from ahriman.models.pkgbuild_patch import PkgbuildPatch
 
 
 def test_packages(watcher: Watcher, package_ahriman: Package) -> None:
@@ -61,82 +57,6 @@ def test_package_add(watcher: Watcher, package_ahriman: Package, mocker: MockerF
     cache_mock.assert_called_once_with(package_ahriman, pytest.helpers.anyvar(int))
 
 
-def test_package_changes_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must retrieve package changes
-    """
-    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_get")
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-
-    watcher.package_changes_get(package_ahriman.base)
-    cache_mock.assert_called_once_with(package_ahriman.base)
-
-
-def test_package_changes_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
-    """
-    must fail if package is unknown during fetching changes
-    """
-    with pytest.raises(UnknownPackageError):
-        watcher.package_changes_get(package_ahriman.base)
-
-
-def test_package_changes_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must update package changes
-    """
-    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_update")
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-
-    watcher.package_changes_update(package_ahriman.base, Changes())
-    cache_mock.assert_called_once_with(package_ahriman.base, Changes())
-
-
-def test_package_changes_update_failed(watcher: Watcher, package_ahriman: Package) -> None:
-    """
-    must fail if package is unknown during updating changes
-    """
-    with pytest.raises(UnknownPackageError):
-        watcher.package_changes_update(package_ahriman.base, Changes())
-
-
-def test_package_dependencies_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must retrieve package dependencies
-    """
-    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_dependencies_get")
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-
-    watcher.package_dependencies_get(package_ahriman.base)
-    cache_mock.assert_called_once_with(package_ahriman.base)
-
-
-def test_package_dependencies_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
-    """
-    must fail if package is unknown during fetching dependencies
-    """
-    with pytest.raises(UnknownPackageError):
-        watcher.package_dependencies_get(package_ahriman.base)
-
-
-def test_package_dependencies_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must update package dependencies
-    """
-    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_dependencies_update")
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-
-    watcher.package_dependencies_update(package_ahriman.base, Dependencies())
-    cache_mock.assert_called_once_with(package_ahriman.base, Dependencies())
-
-
-def test_package_dependencies_update_failed(watcher: Watcher, package_ahriman: Package) -> None:
-    """
-    must fail if package is unknown during updating dependencies
-    """
-    with pytest.raises(UnknownPackageError):
-        watcher.package_dependencies_update(package_ahriman.base, Dependencies())
-
-
 def test_package_get(watcher: Watcher, package_ahriman: Package) -> None:
     """
     must return package status
@@ -155,99 +75,36 @@ def test_package_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
         watcher.package_get(package_ahriman.base)
 
 
-def test_package_logs_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must return package logs
-    """
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-    logs_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_get")
-
-    watcher.package_logs_get(package_ahriman.base, 1, 2)
-    logs_mock.assert_called_once_with(package_ahriman.base, 1, 2)
-
-
-def test_package_logs_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
-    """
-    must raise UnknownPackageError on logs in case of unknown package
-    """
-    with pytest.raises(UnknownPackageError):
-        watcher.package_logs_get(package_ahriman.base)
-
-
-def test_package_logs_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must remove package logs
-    """
-    logs_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_remove")
-    watcher.package_logs_remove(package_ahriman.base, "42")
-    logs_mock.assert_called_once_with(package_ahriman.base, "42")
-
-
-def test_package_logs_update_new(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+def test_package_logs_add_new(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must create package logs record for new package
     """
-    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove")
+    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove", create=True)
     insert_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_add")
 
     log_record_id = LogRecordId(package_ahriman.base, watcher._last_log_record_id.version)
     assert watcher._last_log_record_id != log_record_id
 
-    watcher.package_logs_update(log_record_id, 42.01, "log record")
+    watcher.package_logs_add(log_record_id, 42.01, "log record")
     delete_mock.assert_called_once_with(package_ahriman.base, log_record_id.version)
     insert_mock.assert_called_once_with(log_record_id, 42.01, "log record")
 
     assert watcher._last_log_record_id == log_record_id
 
 
-def test_package_logs_update_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+def test_package_logs_add_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must create package logs record for current package
     """
-    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove")
+    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove", create=True)
     insert_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_add")
 
     log_record_id = LogRecordId(package_ahriman.base, watcher._last_log_record_id.version)
     watcher._last_log_record_id = log_record_id
 
-    watcher.package_logs_update(log_record_id, 42.01, "log record")
+    watcher.package_logs_add(log_record_id, 42.01, "log record")
     delete_mock.assert_not_called()
     insert_mock.assert_called_once_with(log_record_id, 42.01, "log record")
-
-
-def test_package_patches_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must return patches for the package
-    """
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-    patches_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_get")
-
-    watcher.package_patches_get(package_ahriman.base, None)
-    watcher.package_patches_get(package_ahriman.base, "var")
-    patches_mock.assert_has_calls([
-        MockCall(package_ahriman.base, None),
-        MockCall(package_ahriman.base, "var"),
-    ])
-
-
-def test_package_patches_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must remove patches for the package
-    """
-    patches_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_remove")
-    watcher.package_patches_remove(package_ahriman.base, "var")
-    patches_mock.assert_called_once_with(package_ahriman.base, "var")
-
-
-def test_package_patches_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must update patches for the package
-    """
-    patch = PkgbuildPatch("key", "value")
-    patches_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_update")
-
-    watcher.package_patches_update(package_ahriman.base, patch)
-    patches_mock.assert_called_once_with(package_ahriman.base, patch)
 
 
 def test_package_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
@@ -255,7 +112,7 @@ def test_package_remove(watcher: Watcher, package_ahriman: Package, mocker: Mock
     must remove package base
     """
     cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_remove")
-    logs_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove")
+    logs_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove", create=True)
     watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
 
     watcher.package_remove(package_ahriman.base)
@@ -301,3 +158,41 @@ def test_status_update(watcher: Watcher) -> None:
     """
     watcher.status_update(BuildStatusEnum.Success)
     assert watcher.status.status == BuildStatusEnum.Success
+
+
+def test_call(watcher: Watcher, package_ahriman: Package) -> None:
+    """
+    must return self instance if package exists
+    """
+    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
+    assert watcher(package_ahriman.base)
+
+
+def test_call_skip(watcher: Watcher) -> None:
+    """
+    must return self instance if no package base set
+    """
+    assert watcher(None)
+
+
+def test_call_failed(watcher: Watcher, package_ahriman: Package) -> None:
+    """
+    must raise UnknownPackage
+    """
+    with pytest.raises(UnknownPackageError):
+        assert watcher(package_ahriman.base)
+
+
+def test_getattr(watcher: Watcher) -> None:
+    """
+    must return client method call
+    """
+    assert watcher.package_logs_remove
+
+
+def test_getattr_unknown_method(watcher: Watcher) -> None:
+    """
+    must raise AttributeError in case if no reporter attribute found
+    """
+    with pytest.raises(AttributeError):
+        assert watcher.random_method

--- a/tests/ahriman/core/status/test_watcher.py
+++ b/tests/ahriman/core/status/test_watcher.py
@@ -7,20 +7,31 @@ from ahriman.core.exceptions import UnknownPackageError
 from ahriman.core.status.watcher import Watcher
 from ahriman.models.build_status import BuildStatus, BuildStatusEnum
 from ahriman.models.changes import Changes
+from ahriman.models.dependencies import Dependencies
 from ahriman.models.log_record_id import LogRecordId
 from ahriman.models.package import Package
 from ahriman.models.pkgbuild_patch import PkgbuildPatch
+
+
+def test_packages(watcher: Watcher, package_ahriman: Package) -> None:
+    """
+    must return list of available packages
+    """
+    assert not watcher.packages
+
+    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
+    assert watcher.packages
 
 
 def test_load(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must correctly load packages
     """
-    cache_mock = mocker.patch("ahriman.core.database.SQLite.packages_get",
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_get",
                               return_value=[(package_ahriman, BuildStatus())])
 
     watcher.load()
-    cache_mock.assert_called_once_with(watcher.repository_id)
+    cache_mock.assert_called_once_with(None)
     package, status = watcher._known[package_ahriman.base]
     assert package == package_ahriman
     assert status.status == BuildStatusEnum.Unknown
@@ -31,7 +42,7 @@ def test_load_known(watcher: Watcher, package_ahriman: Package, mocker: MockerFi
     must correctly load packages with known statuses
     """
     status = BuildStatus(BuildStatusEnum.Success)
-    mocker.patch("ahriman.core.database.SQLite.packages_get", return_value=[(package_ahriman, status)])
+    mocker.patch("ahriman.core.status.local_client.LocalClient.package_get", return_value=[(package_ahriman, status)])
     watcher._known = {package_ahriman.base: (package_ahriman, status)}
 
     watcher.load()
@@ -39,83 +50,91 @@ def test_load_known(watcher: Watcher, package_ahriman: Package, mocker: MockerFi
     assert status.status == BuildStatusEnum.Success
 
 
-def test_logs_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+def test_package_add(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
-    must return package logs
+    must add package to cache
     """
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-    logs_mock = mocker.patch("ahriman.core.database.SQLite.logs_get")
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_add")
 
-    watcher.logs_get(package_ahriman.base, 1, 2)
-    logs_mock.assert_called_once_with(package_ahriman.base, 1, 2, watcher.repository_id)
-
-
-def test_logs_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
-    """
-    must raise UnknownPackageError on logs in case of unknown package
-    """
-    with pytest.raises(UnknownPackageError):
-        watcher.logs_get(package_ahriman.base)
-
-
-def test_logs_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must remove package logs
-    """
-    logs_mock = mocker.patch("ahriman.core.database.SQLite.logs_remove")
-    watcher.logs_remove(package_ahriman.base, "42")
-    logs_mock.assert_called_once_with(package_ahriman.base, "42", watcher.repository_id)
-
-
-def test_logs_update_new(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must create package logs record for new package
-    """
-    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.logs_remove")
-    insert_mock = mocker.patch("ahriman.core.database.SQLite.logs_insert")
-
-    log_record_id = LogRecordId(package_ahriman.base, watcher._last_log_record_id.version)
-    assert watcher._last_log_record_id != log_record_id
-
-    watcher.logs_update(log_record_id, 42.01, "log record")
-    delete_mock.assert_called_once_with(package_ahriman.base, log_record_id.version)
-    insert_mock.assert_called_once_with(log_record_id, 42.01, "log record", watcher.repository_id)
-
-    assert watcher._last_log_record_id == log_record_id
-
-
-def test_logs_update_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must create package logs record for current package
-    """
-    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.logs_remove")
-    insert_mock = mocker.patch("ahriman.core.database.SQLite.logs_insert")
-
-    log_record_id = LogRecordId(package_ahriman.base, watcher._last_log_record_id.version)
-    watcher._last_log_record_id = log_record_id
-
-    watcher.logs_update(log_record_id, 42.01, "log record")
-    delete_mock.assert_not_called()
-    insert_mock.assert_called_once_with(log_record_id, 42.01, "log record", watcher.repository_id)
+    watcher.package_add(package_ahriman, BuildStatusEnum.Unknown)
+    assert watcher.packages
+    cache_mock.assert_called_once_with(package_ahriman, pytest.helpers.anyvar(int))
 
 
 def test_package_changes_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
-    must return package changes
+    must retrieve package changes
     """
-    get_mock = mocker.patch("ahriman.core.database.SQLite.changes_get", return_value=Changes("sha"))
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_get")
     watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
 
-    assert watcher.package_changes_get(package_ahriman.base) == Changes("sha")
-    get_mock.assert_called_once_with(package_ahriman.base, watcher.repository_id)
+    watcher.package_changes_get(package_ahriman.base)
+    cache_mock.assert_called_once_with(package_ahriman.base)
 
 
 def test_package_changes_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
     """
-    must raise UnknownPackageError on changes in case of unknown package
+    must fail if package is unknown during fetching changes
     """
     with pytest.raises(UnknownPackageError):
         watcher.package_changes_get(package_ahriman.base)
+
+
+def test_package_changes_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must update package changes
+    """
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_changes_update")
+    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
+
+    watcher.package_changes_update(package_ahriman.base, Changes())
+    cache_mock.assert_called_once_with(package_ahriman.base, Changes())
+
+
+def test_package_changes_update_failed(watcher: Watcher, package_ahriman: Package) -> None:
+    """
+    must fail if package is unknown during updating changes
+    """
+    with pytest.raises(UnknownPackageError):
+        watcher.package_changes_update(package_ahriman.base, Changes())
+
+
+def test_package_dependencies_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must retrieve package dependencies
+    """
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_dependencies_get")
+    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
+
+    watcher.package_dependencies_get(package_ahriman.base)
+    cache_mock.assert_called_once_with(package_ahriman.base)
+
+
+def test_package_dependencies_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
+    """
+    must fail if package is unknown during fetching dependencies
+    """
+    with pytest.raises(UnknownPackageError):
+        watcher.package_dependencies_get(package_ahriman.base)
+
+
+def test_package_dependencies_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must update package dependencies
+    """
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_dependencies_update")
+    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
+
+    watcher.package_dependencies_update(package_ahriman.base, Dependencies())
+    cache_mock.assert_called_once_with(package_ahriman.base, Dependencies())
+
+
+def test_package_dependencies_update_failed(watcher: Watcher, package_ahriman: Package) -> None:
+    """
+    must fail if package is unknown during updating dependencies
+    """
+    with pytest.raises(UnknownPackageError):
+        watcher.package_dependencies_update(package_ahriman.base, Dependencies())
 
 
 def test_package_get(watcher: Watcher, package_ahriman: Package) -> None:
@@ -136,17 +155,112 @@ def test_package_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
         watcher.package_get(package_ahriman.base)
 
 
+def test_package_logs_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must return package logs
+    """
+    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
+    logs_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_get")
+
+    watcher.package_logs_get(package_ahriman.base, 1, 2)
+    logs_mock.assert_called_once_with(package_ahriman.base, 1, 2)
+
+
+def test_package_logs_get_failed(watcher: Watcher, package_ahriman: Package) -> None:
+    """
+    must raise UnknownPackageError on logs in case of unknown package
+    """
+    with pytest.raises(UnknownPackageError):
+        watcher.package_logs_get(package_ahriman.base)
+
+
+def test_package_logs_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must remove package logs
+    """
+    logs_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_remove")
+    watcher.package_logs_remove(package_ahriman.base, "42")
+    logs_mock.assert_called_once_with(package_ahriman.base, "42")
+
+
+def test_package_logs_update_new(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must create package logs record for new package
+    """
+    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove")
+    insert_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_add")
+
+    log_record_id = LogRecordId(package_ahriman.base, watcher._last_log_record_id.version)
+    assert watcher._last_log_record_id != log_record_id
+
+    watcher.package_logs_update(log_record_id, 42.01, "log record")
+    delete_mock.assert_called_once_with(package_ahriman.base, log_record_id.version)
+    insert_mock.assert_called_once_with(log_record_id, 42.01, "log record")
+
+    assert watcher._last_log_record_id == log_record_id
+
+
+def test_package_logs_update_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must create package logs record for current package
+    """
+    delete_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove")
+    insert_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_logs_add")
+
+    log_record_id = LogRecordId(package_ahriman.base, watcher._last_log_record_id.version)
+    watcher._last_log_record_id = log_record_id
+
+    watcher.package_logs_update(log_record_id, 42.01, "log record")
+    delete_mock.assert_not_called()
+    insert_mock.assert_called_once_with(log_record_id, 42.01, "log record")
+
+
+def test_package_patches_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must return patches for the package
+    """
+    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
+    patches_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_get")
+
+    watcher.package_patches_get(package_ahriman.base, None)
+    watcher.package_patches_get(package_ahriman.base, "var")
+    patches_mock.assert_has_calls([
+        MockCall(package_ahriman.base, None),
+        MockCall(package_ahriman.base, "var"),
+    ])
+
+
+def test_package_patches_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must remove patches for the package
+    """
+    patches_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_remove")
+    watcher.package_patches_remove(package_ahriman.base, "var")
+    patches_mock.assert_called_once_with(package_ahriman.base, "var")
+
+
+def test_package_patches_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must update patches for the package
+    """
+    patch = PkgbuildPatch("key", "value")
+    patches_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_patches_update")
+
+    watcher.package_patches_update(package_ahriman.base, patch)
+    patches_mock.assert_called_once_with(package_ahriman.base, patch)
+
+
 def test_package_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must remove package base
     """
-    cache_mock = mocker.patch("ahriman.core.database.SQLite.package_remove")
-    logs_mock = mocker.patch("ahriman.core.status.watcher.Watcher.logs_remove")
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_remove")
+    logs_mock = mocker.patch("ahriman.core.status.watcher.Watcher.package_logs_remove")
     watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
 
     watcher.package_remove(package_ahriman.base)
     assert not watcher._known
-    cache_mock.assert_called_once_with(package_ahriman.base, watcher.repository_id)
+    cache_mock.assert_called_once_with(package_ahriman.base)
     logs_mock.assert_called_once_with(package_ahriman.base, None)
 
 
@@ -154,34 +268,20 @@ def test_package_remove_unknown(watcher: Watcher, package_ahriman: Package, mock
     """
     must not fail on unknown base removal
     """
-    cache_mock = mocker.patch("ahriman.core.database.SQLite.package_remove")
-
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_remove")
     watcher.package_remove(package_ahriman.base)
-    cache_mock.assert_called_once_with(package_ahriman.base, watcher.repository_id)
+    cache_mock.assert_called_once_with(package_ahriman.base)
 
 
 def test_package_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
-    must update package status
-    """
-    cache_mock = mocker.patch("ahriman.core.database.SQLite.package_update")
-
-    watcher.package_update(package_ahriman.base, BuildStatusEnum.Unknown, package_ahriman)
-    cache_mock.assert_called_once_with(package_ahriman, pytest.helpers.anyvar(int), watcher.repository_id)
-    package, status = watcher._known[package_ahriman.base]
-    assert package == package_ahriman
-    assert status.status == BuildStatusEnum.Unknown
-
-
-def test_package_update_ping(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
     must update package status only for known package
     """
-    cache_mock = mocker.patch("ahriman.core.database.SQLite.package_update")
+    cache_mock = mocker.patch("ahriman.core.status.local_client.LocalClient.package_update")
     watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
 
-    watcher.package_update(package_ahriman.base, BuildStatusEnum.Success, None)
-    cache_mock.assert_called_once_with(package_ahriman, pytest.helpers.anyvar(int), watcher.repository_id)
+    watcher.package_update(package_ahriman.base, BuildStatusEnum.Success)
+    cache_mock.assert_called_once_with(package_ahriman.base, pytest.helpers.anyvar(int))
     package, status = watcher._known[package_ahriman.base]
     assert package == package_ahriman
     assert status.status == BuildStatusEnum.Success
@@ -192,44 +292,7 @@ def test_package_update_unknown(watcher: Watcher, package_ahriman: Package) -> N
     must fail on unknown package status update only
     """
     with pytest.raises(UnknownPackageError):
-        watcher.package_update(package_ahriman.base, BuildStatusEnum.Unknown, None)
-
-
-def test_patches_get(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must return patches for the package
-    """
-    watcher._known = {package_ahriman.base: (package_ahriman, BuildStatus())}
-    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_list")
-
-    watcher.patches_get(package_ahriman.base, None)
-    watcher.patches_get(package_ahriman.base, "var")
-    patches_mock.assert_has_calls([
-        MockCall(package_ahriman.base, None),
-        MockCall().get(package_ahriman.base, []),
-        MockCall(package_ahriman.base, ["var"]),
-        MockCall().get(package_ahriman.base, []),
-    ])
-
-
-def test_patches_remove(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must remove patches for the package
-    """
-    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_remove")
-    watcher.patches_remove(package_ahriman.base, "var")
-    patches_mock.assert_called_once_with(package_ahriman.base, ["var"])
-
-
-def test_patches_update(watcher: Watcher, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must update patches for the package
-    """
-    patch = PkgbuildPatch("key", "value")
-    patches_mock = mocker.patch("ahriman.core.database.SQLite.patches_insert")
-
-    watcher.patches_update(package_ahriman.base, patch)
-    patches_mock.assert_called_once_with(package_ahriman.base, [patch])
+        watcher.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
 
 
 def test_status_update(watcher: Watcher) -> None:

--- a/tests/ahriman/core/status/test_web_client.py
+++ b/tests/ahriman/core/status/test_web_client.py
@@ -97,59 +97,6 @@ def test_status_url(web_client: WebClient) -> None:
     assert web_client._status_url().endswith("/api/v1/status")
 
 
-def test_package_add(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must process package addition
-    """
-    requests_mock = mocker.patch("ahriman.core.status.web_client.WebClient.make_request")
-    payload = pytest.helpers.get_package_status(package_ahriman)
-
-    web_client.package_add(package_ahriman, BuildStatusEnum.Unknown)
-    requests_mock.assert_called_once_with("POST", pytest.helpers.anyvar(str, True),
-                                          params=web_client.repository_id.query(), json=payload)
-
-
-def test_package_add_failed(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must suppress any exception happened during addition
-    """
-    mocker.patch("requests.Session.request", side_effect=Exception())
-    web_client.package_add(package_ahriman, BuildStatusEnum.Unknown)
-
-
-def test_package_add_failed_http_error(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must suppress HTTP exception happened during addition
-    """
-    mocker.patch("requests.Session.request", side_effect=requests.HTTPError())
-    web_client.package_add(package_ahriman, BuildStatusEnum.Unknown)
-
-
-def test_package_add_failed_suppress(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
-    """
-    must suppress any exception happened during addition and don't log
-    """
-    web_client.suppress_errors = True
-    mocker.patch("requests.Session.request", side_effect=Exception())
-    logging_mock = mocker.patch("logging.exception")
-
-    web_client.package_add(package_ahriman, BuildStatusEnum.Unknown)
-    logging_mock.assert_not_called()
-
-
-def test_package_add_failed_http_error_suppress(web_client: WebClient, package_ahriman: Package,
-                                                mocker: MockerFixture) -> None:
-    """
-    must suppress HTTP exception happened during addition and don't log
-    """
-    web_client.suppress_errors = True
-    mocker.patch("requests.Session.request", side_effect=requests.HTTPError())
-    logging_mock = mocker.patch("logging.exception")
-
-    web_client.package_add(package_ahriman, BuildStatusEnum.Unknown)
-    logging_mock.assert_not_called()
-
-
 def test_package_changes_get(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must get changes
@@ -785,13 +732,13 @@ def test_package_remove_failed_http_error(web_client: WebClient, package_ahriman
     web_client.package_remove(package_ahriman.base)
 
 
-def test_package_update(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+def test_package_status_update(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must process package update
     """
     requests_mock = mocker.patch("ahriman.core.status.web_client.WebClient.make_request")
 
-    web_client.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
+    web_client.package_status_update(package_ahriman.base, BuildStatusEnum.Unknown)
     requests_mock.assert_called_once_with("POST", pytest.helpers.anyvar(str, True),
                                           params=web_client.repository_id.query(),
                                           json={
@@ -799,21 +746,75 @@ def test_package_update(web_client: WebClient, package_ahriman: Package, mocker:
     })
 
 
-def test_package_update_failed(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+def test_package_status_update_failed(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
     """
     must suppress any exception happened during update
     """
     mocker.patch("requests.Session.request", side_effect=Exception())
-    web_client.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
+    web_client.package_status_update(package_ahriman.base, BuildStatusEnum.Unknown)
+
+
+def test_package_status_update_failed_http_error(web_client: WebClient, package_ahriman: Package,
+                                                 mocker: MockerFixture) -> None:
+    """
+    must suppress HTTP exception happened during update
+    """
+    mocker.patch("requests.Session.request", side_effect=requests.HTTPError())
+    web_client.package_status_update(package_ahriman.base, BuildStatusEnum.Unknown)
+
+
+def test_package_update(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must process package addition
+    """
+    requests_mock = mocker.patch("ahriman.core.status.web_client.WebClient.make_request")
+    payload = pytest.helpers.get_package_status(package_ahriman)
+
+    web_client.package_update(package_ahriman, BuildStatusEnum.Unknown)
+    requests_mock.assert_called_once_with("POST", pytest.helpers.anyvar(str, True),
+                                          params=web_client.repository_id.query(), json=payload)
+
+
+def test_package_update_failed(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must suppress any exception happened during addition
+    """
+    mocker.patch("requests.Session.request", side_effect=Exception())
+    web_client.package_update(package_ahriman, BuildStatusEnum.Unknown)
 
 
 def test_package_update_failed_http_error(web_client: WebClient, package_ahriman: Package,
                                           mocker: MockerFixture) -> None:
     """
-    must suppress HTTP exception happened during update
+    must suppress HTTP exception happened during addition
     """
     mocker.patch("requests.Session.request", side_effect=requests.HTTPError())
-    web_client.package_update(package_ahriman.base, BuildStatusEnum.Unknown)
+    web_client.package_update(package_ahriman, BuildStatusEnum.Unknown)
+
+
+def test_package_update_failed_suppress(web_client: WebClient, package_ahriman: Package, mocker: MockerFixture) -> None:
+    """
+    must suppress any exception happened during addition and don't log
+    """
+    web_client.suppress_errors = True
+    mocker.patch("requests.Session.request", side_effect=Exception())
+    logging_mock = mocker.patch("logging.exception")
+
+    web_client.package_update(package_ahriman, BuildStatusEnum.Unknown)
+    logging_mock.assert_not_called()
+
+
+def test_package_update_failed_http_error_suppress(web_client: WebClient, package_ahriman: Package,
+                                                   mocker: MockerFixture) -> None:
+    """
+    must suppress HTTP exception happened during addition and don't log
+    """
+    web_client.suppress_errors = True
+    mocker.patch("requests.Session.request", side_effect=requests.HTTPError())
+    logging_mock = mocker.patch("logging.exception")
+
+    web_client.package_update(package_ahriman, BuildStatusEnum.Unknown)
+    logging_mock.assert_not_called()
 
 
 def test_status_get(web_client: WebClient, mocker: MockerFixture) -> None:

--- a/tests/ahriman/core/support/test_package_creator.py
+++ b/tests/ahriman/core/support/test_package_creator.py
@@ -1,8 +1,7 @@
-import pytest
-
+from pathlib import Path
 from pytest_mock import MockerFixture
 
-from ahriman.core.database import SQLite
+from ahriman.core.status import Client
 from ahriman.core.support.package_creator import PackageCreator
 from ahriman.models.package import Package
 from ahriman.models.package_description import PackageDescription
@@ -10,32 +9,52 @@ from ahriman.models.package_source import PackageSource
 from ahriman.models.remote_source import RemoteSource
 
 
-def test_run(package_creator: PackageCreator, database: SQLite, mocker: MockerFixture) -> None:
+def test_package_create(package_creator: PackageCreator, mocker: MockerFixture) -> None:
     """
-    must correctly process package creation
+    must create package
     """
+    path = Path("local")
+    rmtree_mock = mocker.patch("shutil.rmtree")
+    mkdir_mock = mocker.patch("pathlib.Path.mkdir")
+    write_mock = mocker.patch("ahriman.core.support.pkgbuild.pkgbuild_generator.PkgbuildGenerator.write_pkgbuild")
+    init_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.init")
+
+    package_creator.package_create(path)
+    rmtree_mock.assert_called_once_with(path, ignore_errors=True)
+    mkdir_mock.assert_called_once_with(mode=0o755, parents=True, exist_ok=True)
+    write_mock.assert_called_once_with(path)
+    init_mock.assert_called_once_with(path)
+
+
+def test_package_register(package_creator: PackageCreator, mocker: MockerFixture) -> None:
+    """
+    must register package
+    """
+    path = Path("local")
     package = Package(
         base=package_creator.generator.pkgname,
         version=package_creator.generator.pkgver,
         remote=RemoteSource(source=PackageSource.Local),
         packages={package_creator.generator.pkgname: PackageDescription()},
     )
-    local_path = package_creator.configuration.repository_paths.cache_for(package_creator.generator.pkgname)
-
-    rmtree_mock = mocker.patch("shutil.rmtree")
-    database_mock = mocker.patch("ahriman.core._Context.get", return_value=database)
-    init_mock = mocker.patch("ahriman.core.build_tools.sources.Sources.init")
-    insert_mock = mocker.patch("ahriman.core.database.SQLite.package_update")
-    mkdir_mock = mocker.patch("pathlib.Path.mkdir")
+    client_mock = mocker.patch("ahriman.core._Context.get", return_value=Client())
+    insert_mock = mocker.patch("ahriman.core.status.Client.set_unknown")
     package_mock = mocker.patch("ahriman.models.package.Package.from_build", return_value=package)
-    write_mock = mocker.patch("ahriman.core.support.pkgbuild.pkgbuild_generator.PkgbuildGenerator.write_pkgbuild")
+
+    package_creator.package_register(path)
+    package_mock.assert_called_once_with(path, "x86_64", None)
+    client_mock.assert_called_once_with(Client)
+    insert_mock.assert_called_once_with(package)
+
+
+def test_run(package_creator: PackageCreator, mocker: MockerFixture) -> None:
+    """
+    must correctly process package creation
+    """
+    path = package_creator.configuration.repository_paths.cache_for(package_creator.generator.pkgname)
+    create_mock = mocker.patch("ahriman.core.support.package_creator.PackageCreator.package_create")
+    register_mock = mocker.patch("ahriman.core.support.package_creator.PackageCreator.package_register")
 
     package_creator.run()
-    rmtree_mock.assert_called_once_with(local_path, ignore_errors=True)
-    mkdir_mock.assert_called_once_with(mode=0o755, parents=True, exist_ok=True)
-    write_mock.assert_called_once_with(local_path)
-    init_mock.assert_called_once_with(local_path)
-
-    package_mock.assert_called_once_with(local_path, "x86_64", None)
-    database_mock.assert_called_once_with(SQLite)
-    insert_mock.assert_called_once_with(package, pytest.helpers.anyvar(int))
+    create_mock.assert_called_once_with(path)
+    register_mock.assert_called_once_with(path)

--- a/tests/ahriman/core/test_util.py
+++ b/tests/ahriman/core/test_util.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import os
 import pytest
-import shlex
 
 from pathlib import Path
 from pytest_mock import MockerFixture

--- a/tests/ahriman/models/test_dependencies.py
+++ b/tests/ahriman/models/test_dependencies.py
@@ -1,0 +1,9 @@
+from ahriman.models.dependencies import Dependencies
+
+
+def test_from_json_view() -> None:
+    """
+    must construct and serialize dependencies to json
+    """
+    dependencies = Dependencies({"/usr/bin/python3": ["python"]})
+    assert Dependencies.from_json(dependencies.view()) == dependencies

--- a/tests/ahriman/models/test_package_archive.py
+++ b/tests/ahriman/models/test_package_archive.py
@@ -65,13 +65,11 @@ def test_depends_on(package_archive_ahriman: PackageArchive, mocker: MockerFixtu
     ))
 
     result = package_archive_ahriman.depends_on()
-    assert result.package_base == package_archive_ahriman.package.base
     assert result.paths == {
-        Path("package1") / "file1": ["package1"],
-        Path("package2") / "file3": ["package2"],
-        Path("package2") / "dir4": ["package2"],
-        Path("package2") / "file3": ["package2"],
-        Path("usr") / "dir2": ["package1", "package2"]
+        "package1/file1": ["package1"],
+        "package2/file3": ["package2"],
+        "package2/dir4": ["package2"],
+        "usr/dir2": ["package1", "package2"]
     }
 
 

--- a/tests/ahriman/models/test_pkgbuild_patch.py
+++ b/tests/ahriman/models/test_pkgbuild_patch.py
@@ -51,6 +51,14 @@ def test_from_env() -> None:
     assert PkgbuildPatch.from_env("KEY") == PkgbuildPatch("KEY", "")
 
 
+def test_from_json_view() -> None:
+    """
+    must correctly serialize to json
+    """
+    patch = PkgbuildPatch("key", "value")
+    assert PkgbuildPatch.from_json(patch.view()) == patch
+
+
 def test_parse() -> None:
     """
     must parse string correctly
@@ -122,13 +130,6 @@ def test_serialize_list() -> None:
     """
     assert PkgbuildPatch("arch", ["i686", "x86_64"]).serialize() == """arch=(i686 x86_64)"""
     assert PkgbuildPatch("key", ["val'ue", "val\"ue2"]).serialize() == """key=('val'"'"'ue' 'val"ue2')"""
-
-
-def test_view() -> None:
-    """
-    must correctly serialize to json
-    """
-    assert PkgbuildPatch("key", "value").view() == {"key": "key", "value": "value"}
 
 
 def test_write(mocker: MockerFixture) -> None:

--- a/tests/ahriman/models/test_repository_id.py
+++ b/tests/ahriman/models/test_repository_id.py
@@ -60,4 +60,4 @@ def test_lt_invalid() -> None:
     must raise ValueError if other is not valid repository id
     """
     with pytest.raises(ValueError):
-        RepositoryId("x86_64", "a") < 42
+        assert RepositoryId("x86_64", "a") < 42

--- a/tests/ahriman/web/schemas/test_dependencies_schema.py
+++ b/tests/ahriman/web/schemas/test_dependencies_schema.py
@@ -1,0 +1,1 @@
+# schema testing goes in view class tests

--- a/tests/ahriman/web/schemas/test_package_version_schema.py
+++ b/tests/ahriman/web/schemas/test_package_version_schema.py
@@ -1,0 +1,1 @@
+# schema testing goes in view class tests

--- a/tests/ahriman/web/views/test_view_base.py
+++ b/tests/ahriman/web/views/test_view_base.py
@@ -7,6 +7,7 @@ from pytest_mock import MockerFixture
 from unittest.mock import AsyncMock
 
 from ahriman.core.configuration import Configuration
+from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.repository_id import RepositoryId
 from ahriman.models.user_access import UserAccess
 from ahriman.web.keys import WatcherKey
@@ -202,6 +203,15 @@ def test_service_not_found(base: BaseView) -> None:
     """
     with pytest.raises(HTTPNotFound):
         base.service(RepositoryId("", ""))
+
+
+def test_service_package(base: BaseView, repository_id: RepositoryId, mocker: MockerFixture) -> None:
+    """
+    must validate that package exists
+    """
+    mocker.patch("ahriman.web.views.base.BaseView.repository_id", return_value=repository_id)
+    with pytest.raises(UnknownPackageError):
+        base.service(package_base="base")
 
 
 async def test_username(base: BaseView, mocker: MockerFixture) -> None:

--- a/tests/ahriman/web/views/test_view_base.py
+++ b/tests/ahriman/web/views/test_view_base.py
@@ -7,7 +7,6 @@ from pytest_mock import MockerFixture
 from unittest.mock import AsyncMock
 
 from ahriman.core.configuration import Configuration
-from ahriman.core.exceptions import UnknownPackageError
 from ahriman.models.repository_id import RepositoryId
 from ahriman.models.user_access import UserAccess
 from ahriman.web.keys import WatcherKey
@@ -210,7 +209,7 @@ def test_service_package(base: BaseView, repository_id: RepositoryId, mocker: Mo
     must validate that package exists
     """
     mocker.patch("ahriman.web.views.base.BaseView.repository_id", return_value=repository_id)
-    with pytest.raises(UnknownPackageError):
+    with pytest.raises(HTTPNotFound):
         base.service(package_base="base")
 
 

--- a/tests/ahriman/web/views/v1/packages/test_view_v1_packages_changes.py
+++ b/tests/ahriman/web/views/v1/packages/test_view_v1_packages_changes.py
@@ -82,14 +82,3 @@ async def test_post_exception(client: TestClient, package_ahriman: Package) -> N
     response = await client.post(f"/api/v1/packages/{package_ahriman.base}/changes", json=[])
     assert response.status == 400
     assert not response_schema.validate(await response.json())
-
-
-async def test_post_not_found(client: TestClient, package_ahriman: Package) -> None:
-    """
-    must raise exception on unknown package
-    """
-    response_schema = pytest.helpers.schema_response(ChangesView.post, code=404)
-
-    response = await client.post(f"/api/v1/packages/{package_ahriman.base}/changes", json={})
-    assert response.status == 404
-    assert not response_schema.validate(await response.json())

--- a/tests/ahriman/web/views/v1/packages/test_view_v1_packages_logs.py
+++ b/tests/ahriman/web/views/v1/packages/test_view_v1_packages_logs.py
@@ -40,6 +40,18 @@ async def test_delete(client: TestClient, package_ahriman: Package, package_pyth
                       json={"created": 42.0, "message": "message", "version": "42"})
     await client.post(f"/api/v1/packages/{package_python_schedule.base}/logs",
                       json={"created": 42.0, "message": "message", "version": "42"})
+    request_schema = pytest.helpers.schema_request(LogsView.delete, location="querystring")
+
+    payload = {}
+    assert not request_schema.validate(payload)
+    payload = {"version": "42"}
+
+    response = await client.delete(f"/api/v1/packages/{package_ahriman.base}/logs", params=payload)
+    assert response.status == 204
+
+    response = await client.get(f"/api/v1/packages/{package_ahriman.base}/logs")
+    logs = await response.json()
+    assert logs["logs"]
 
     response = await client.delete(f"/api/v1/packages/{package_ahriman.base}/logs")
     assert response.status == 204

--- a/tests/ahriman/web/views/v1/packages/test_view_v1_packages_logs.py
+++ b/tests/ahriman/web/views/v1/packages/test_view_v1_packages_logs.py
@@ -37,9 +37,9 @@ async def test_delete(client: TestClient, package_ahriman: Package, package_pyth
                       json={"status": BuildStatusEnum.Success.value, "package": package_python_schedule.view()})
 
     await client.post(f"/api/v1/packages/{package_ahriman.base}/logs",
-                      json={"created": 42.0, "message": "message", "version": "42"})
+                      json={"created": 42.0, "message": "message 1", "version": "42"})
     await client.post(f"/api/v1/packages/{package_python_schedule.base}/logs",
-                      json={"created": 42.0, "message": "message", "version": "42"})
+                      json={"created": 42.0, "message": "message 2", "version": "42"})
     request_schema = pytest.helpers.schema_request(LogsView.delete, location="querystring")
 
     payload = {}

--- a/tests/ahriman/web/views/v1/packages/test_view_v1_packages_patches.py
+++ b/tests/ahriman/web/views/v1/packages/test_view_v1_packages_patches.py
@@ -64,6 +64,24 @@ async def test_post(client: TestClient, package_ahriman: Package) -> None:
     assert patches == [payload]
 
 
+async def test_post_full_diff(client: TestClient, package_ahriman: Package) -> None:
+    """
+    must create patch from full diff
+    """
+    await client.post(f"/api/v1/packages/{package_ahriman.base}",
+                      json={"status": BuildStatusEnum.Success.value, "package": package_ahriman.view()})
+    request_schema = pytest.helpers.schema_request(PatchesView.post)
+
+    payload = {"value": "v"}
+    assert not request_schema.validate(payload)
+    response = await client.post(f"/api/v1/packages/{package_ahriman.base}/patches", json=payload)
+    assert response.status == 204
+
+    response = await client.get(f"/api/v1/packages/{package_ahriman.base}/patches")
+    patches = await response.json()
+    assert patches == [payload]
+
+
 async def test_post_exception(client: TestClient, package_ahriman: Package) -> None:
     """
     must raise exception on invalid payload

--- a/tests/ahriman/web/views/v1/status/test_view_v1_status_info.py
+++ b/tests/ahriman/web/views/v1/status/test_view_v1_status_info.py
@@ -30,7 +30,7 @@ async def test_get(client: TestClient, repository_id: RepositoryId) -> None:
     """
     response_schema = pytest.helpers.schema_response(InfoView.get)
 
-    response = await client.get(f"/api/v1/info")
+    response = await client.get("/api/v1/info")
     assert response.ok
     json = await response.json()
     assert not response_schema.validate(json)

--- a/tests/ahriman/web/views/v1/status/test_view_v1_status_repositories.py
+++ b/tests/ahriman/web/views/v1/status/test_view_v1_status_repositories.py
@@ -29,7 +29,7 @@ async def test_get(client: TestClient, repository_id: RepositoryId) -> None:
     """
     response_schema = pytest.helpers.schema_response(RepositoriesView.get)
 
-    response = await client.get(f"/api/v1/repositories")
+    response = await client.get("/api/v1/repositories")
     assert response.ok
     json = await response.json()
     assert not response_schema.validate(json, many=True)


### PR DESCRIPTION
## Summary

This mr improves client class with bunch of update/get methods and also makes write to database more straight-forward. Now if client loads without reporting, it will use local (database) mode and web interaction otherwise.

Note, however, that some methods still require direct interaction with database - e.g. build queue and user operations.

Other changes:
* Some methods inside clients and watcher have been renamed for better consistency.
* `patch-list` command now requires package to be set.
* Dependencies now operates with strings instead of paths. Some methods have been also adjusted.

Closes #123

### Checklist

- [x] Tests to cover new code
- [x] `tox` passed
